### PR TITLE
feat: add linux release packaging workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Create and push tag
         run: |
           git tag "v${{ steps.select_version.outputs.version }}"
-          git push origin HEAD
+          git push origin "HEAD:${{ github.ref_name }}"
           git push origin "v${{ steps.select_version.outputs.version }}"
 
   publish_artifact:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,138 @@
+name: Publish
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: Select the semantic version bump
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bump_and_tag:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.select_version.outputs.version }}
+      tag: v${{ steps.select_version.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Get previous tag
+        id: previous_tag
+        uses: WyriHaximus/github-action-get-previous-tag@v2
+        with:
+          fallback: v0.0.0
+
+      - name: Calculate next versions
+        id: next_semver
+        uses: WyriHaximus/github-action-next-semvers@v1
+        with:
+          version: ${{ steps.previous_tag.outputs.tag }}
+
+      - name: Select release version
+        id: select_version
+        run: |
+          case "${{ github.event.inputs.release_type }}" in
+            patch) version="${{ steps.next_semver.outputs.patch }}" ;;
+            minor) version="${{ steps.next_semver.outputs.minor }}" ;;
+            major) version="${{ steps.next_semver.outputs.major }}" ;;
+            *) echo "unsupported release type" >&2; exit 1 ;;
+          esac
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Update package version
+        run: npm version "${{ steps.select_version.outputs.version }}" --no-git-tag-version
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json
+          git commit -m "chore: release v${{ steps.select_version.outputs.version }}"
+
+      - name: Create and push tag
+        run: |
+          git tag "v${{ steps.select_version.outputs.version }}"
+          git push origin HEAD
+          git push origin "v${{ steps.select_version.outputs.version }}"
+
+  publish_artifact:
+    runs-on: ubuntu-latest
+    needs:
+      - bump_and_tag
+    if: always() && (github.event_name == 'push' || needs.bump_and_tag.result == 'success')
+    permissions:
+      contents: write
+    env:
+      RELEASE_TAG: ${{ github.event_name == 'push' && github.ref_name || needs.bump_and_tag.outputs.tag }}
+    steps:
+      - name: Checkout release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_TAG }}
+
+      - name: Resolve release version
+        id: release_version
+        run: |
+          version="${RELEASE_TAG#v}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Package release artifact
+        id: package
+        run: |
+          artifact_path="$(npm run --silent package:release -- "${{ steps.release_version.outputs.version }}")"
+          echo "artifact_path=${artifact_path}" >> "${GITHUB_OUTPUT}"
+          echo "artifact_name=$(basename "${artifact_path}")" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.package.outputs.artifact_name }}
+          path: ${{ steps.package.outputs.artifact_path }}
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          files: ${{ steps.package.outputs.artifact_path }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 dist
+artifacts
 data
 .env
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ npm install
 npm run build
 ```
 
+For server deployments, prefer the release artifact from GitHub Releases instead of cloning the repo. Each release publishes `ai-agent-desktop-manager-vX.Y.Z-linux-x64.tar.gz`.
+
+### Install from release artifact
+
+```bash
+curl -LO https://github.com/markcallen/ai-agent-desktop-manager/releases/download/vX.Y.Z/ai-agent-desktop-manager-vX.Y.Z-linux-x64.tar.gz
+tar -xzf ai-agent-desktop-manager-vX.Y.Z-linux-x64.tar.gz
+cd ai-agent-desktop-manager
+sudo ./scripts/install-release.sh
+```
+
 ### Configure
 
 Copy and edit `.env.example`:
@@ -146,35 +157,39 @@ This allows:
 
 ## Deployment runbook (systemd)
 
-1. Build the project:
+1. Download and unpack the release artifact:
 
 ```bash
-npm install
-npm run build
+curl -LO https://github.com/markcallen/ai-agent-desktop-manager/releases/download/vX.Y.Z/ai-agent-desktop-manager-vX.Y.Z-linux-x64.tar.gz
+tar -xzf ai-agent-desktop-manager-vX.Y.Z-linux-x64.tar.gz
+cd ai-agent-desktop-manager
 ```
 
-2. Copy units and sudoers:
+2. Install runtime dependencies and service files:
 
 ```bash
-sudo cp systemd/*.service /etc/systemd/system/
-sudo cp ops/sudoers-aadm /etc/sudoers.d/aadm
-sudo chmod 440 /etc/sudoers.d/aadm
+sudo ./scripts/install-release.sh
 ```
 
-3. Reload systemd and enable manager:
+3. Review and edit the environment file:
 
 ```bash
-sudo systemctl daemon-reload
-sudo systemctl enable --now aadm.service
+sudoedit /opt/ai-agent-desktop-manager/.env
 ```
 
-4. Verify manager health:
+4. Reload systemd and restart manager:
+
+```bash
+sudo systemctl restart aadm.service
+```
+
+5. Verify manager health:
 
 ```bash
 curl -s http://127.0.0.1:8899/health | jq
 ```
 
-5. Create and verify one desktop:
+6. Create and verify one desktop:
 
 ```bash
 curl -sX POST http://127.0.0.1:8899/v1/desktops -H 'content-type: application/json' -d '{}' | jq
@@ -255,6 +270,15 @@ ssh -L 8899:127.0.0.1:8899 user@server
 Now your agent running locally can call:
 
 - `http://127.0.0.1:8899`
+
+---
+
+## Publishing releases
+
+GitHub Actions publishes the Linux server artifact from `.github/workflows/publish.yml`.
+
+- `workflow_dispatch` creates the next `patch`, `minor`, or `major` tag, then builds and publishes the artifact.
+- Pushing a `v*` tag builds the artifact from that exact tag and attaches it to a GitHub Release.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "dev": "tsx watch src/index.ts",
     "build": "tsc -p tsconfig.json",
+    "package:release": "bash ./scripts/package-release.sh",
     "start": "node dist/index.js",
     "cli": "tsx src/cli/aadm.ts",
     "aab-console": "tsx src/cli/aab-console.ts",

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -1,12 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SERVICE_USER="${AADM_SERVICE_USER:-aadm}"
-SERVICE_GROUP="${AADM_SERVICE_GROUP:-aadm}"
-INSTALL_DIR="${AADM_INSTALL_DIR:-/opt/ai-agent-desktop-manager}"
+SERVICE_USER="aadm"
+SERVICE_GROUP="aadm"
+INSTALL_DIR="/opt/ai-agent-desktop-manager"
 
 if [[ ! -f "./package.json" || ! -d "./dist" || ! -d "./systemd" ]]; then
   echo "run this script from the extracted release directory" >&2
+  exit 1
+fi
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "this installer must be run as root (try again with sudo)" >&2
   exit 1
 fi
 
@@ -34,7 +39,7 @@ fi
 install -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0644 ./ops/sudoers-aadm "${INSTALL_DIR}/ops/sudoers-aadm"
 
 cd "${INSTALL_DIR}"
-npm ci --omit=dev
+runuser -u "${SERVICE_USER}" -- npm ci --omit=dev
 
 cp ./systemd/*.service /etc/systemd/system/
 cp ./ops/sudoers-aadm /etc/sudoers.d/aadm

--- a/scripts/install-release.sh
+++ b/scripts/install-release.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SERVICE_USER="${AADM_SERVICE_USER:-aadm}"
+SERVICE_GROUP="${AADM_SERVICE_GROUP:-aadm}"
+INSTALL_DIR="${AADM_INSTALL_DIR:-/opt/ai-agent-desktop-manager}"
+
+if [[ ! -f "./package.json" || ! -d "./dist" || ! -d "./systemd" ]]; then
+  echo "run this script from the extracted release directory" >&2
+  exit 1
+fi
+
+if ! getent group "${SERVICE_GROUP}" >/dev/null 2>&1; then
+  groupadd --system "${SERVICE_GROUP}"
+fi
+
+if ! id "${SERVICE_USER}" >/dev/null 2>&1; then
+  useradd -r -m -g "${SERVICE_GROUP}" -s /usr/sbin/nologin "${SERVICE_USER}"
+fi
+
+install -d -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0755 "${INSTALL_DIR}"
+install -d -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0755 "${INSTALL_DIR}/dist"
+install -d -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0755 "${INSTALL_DIR}/systemd"
+cp -R ./dist/. "${INSTALL_DIR}/dist/"
+cp -R ./systemd/. "${INSTALL_DIR}/systemd/"
+chown -R "${SERVICE_USER}:${SERVICE_GROUP}" "${INSTALL_DIR}/dist" "${INSTALL_DIR}/systemd"
+install -d -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0755 "${INSTALL_DIR}/ops"
+install -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0644 ./package.json "${INSTALL_DIR}/package.json"
+install -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0644 ./package-lock.json "${INSTALL_DIR}/package-lock.json"
+install -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0644 ./.env.example "${INSTALL_DIR}/.env.example"
+if [[ ! -f "${INSTALL_DIR}/.env" ]]; then
+  install -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0640 ./.env.example "${INSTALL_DIR}/.env"
+fi
+install -o "${SERVICE_USER}" -g "${SERVICE_GROUP}" -m 0644 ./ops/sudoers-aadm "${INSTALL_DIR}/ops/sudoers-aadm"
+
+cd "${INSTALL_DIR}"
+npm ci --omit=dev
+
+cp ./systemd/*.service /etc/systemd/system/
+cp ./ops/sudoers-aadm /etc/sudoers.d/aadm
+chmod 0440 /etc/sudoers.d/aadm
+
+systemctl daemon-reload
+systemctl enable --now aadm.service
+
+echo "installed to ${INSTALL_DIR}"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+VERSION="${1:-}"
+OUTPUT_DIR="${2:-artifacts}"
+ARCH="${3:-linux-x64}"
+
+if [[ -z "${VERSION}" ]]; then
+  VERSION="$(node -p "require('./package.json').version")"
+fi
+
+if [[ -z "${VERSION}" ]]; then
+  echo "version is required" >&2
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+STAGE_DIR="$(mktemp -d)"
+PACKAGE_DIR="${STAGE_DIR}/ai-agent-desktop-manager"
+ARTIFACT_BASENAME="ai-agent-desktop-manager-v${VERSION}-${ARCH}"
+ARTIFACT_PATH="${ROOT_DIR}/${OUTPUT_DIR}/${ARTIFACT_BASENAME}.tar.gz"
+
+cleanup() {
+  rm -rf "${STAGE_DIR}"
+}
+trap cleanup EXIT
+
+mkdir -p "${PACKAGE_DIR}" "${ROOT_DIR}/${OUTPUT_DIR}"
+
+cp -R "${ROOT_DIR}/dist" "${PACKAGE_DIR}/dist"
+cp -R "${ROOT_DIR}/systemd" "${PACKAGE_DIR}/systemd"
+mkdir -p "${PACKAGE_DIR}/ops" "${PACKAGE_DIR}/scripts"
+cp "${ROOT_DIR}/ops/sudoers-aadm" "${PACKAGE_DIR}/ops/sudoers-aadm"
+cp "${ROOT_DIR}/package.json" "${PACKAGE_DIR}/package.json"
+cp "${ROOT_DIR}/package-lock.json" "${PACKAGE_DIR}/package-lock.json"
+cp "${ROOT_DIR}/README.md" "${PACKAGE_DIR}/README.md"
+cp "${ROOT_DIR}/LICENSE" "${PACKAGE_DIR}/LICENSE"
+cp "${ROOT_DIR}/.env.example" "${PACKAGE_DIR}/.env.example"
+cp "${ROOT_DIR}/scripts/install-release.sh" "${PACKAGE_DIR}/scripts/install-release.sh"
+chmod 0755 "${PACKAGE_DIR}/scripts/install-release.sh"
+
+tar -C "${STAGE_DIR}" -czf "${ARTIFACT_PATH}" "ai-agent-desktop-manager"
+
+echo "${ARTIFACT_PATH}"

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VERSION="${1:-}"
 OUTPUT_DIR="${2:-artifacts}"
 ARCH="${3:-linux-x64}"
 
 if [[ -z "${VERSION}" ]]; then
-  VERSION="$(node -p "require('./package.json').version")"
+  VERSION="$(node -p "require('${ROOT_DIR}/package.json').version")"
 fi
 
 if [[ -z "${VERSION}" ]]; then
   echo "version is required" >&2
   exit 1
 fi
-
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 STAGE_DIR="$(mktemp -d)"
 PACKAGE_DIR="${STAGE_DIR}/ai-agent-desktop-manager"
 ARTIFACT_BASENAME="ai-agent-desktop-manager-v${VERSION}-${ARCH}"

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,8 +31,7 @@ import {
 } from './util/systemd.js';
 import { CreateDesktopBody } from './api/types.js';
 import { isPortOpen } from './util/net.js';
-
-const VERSION = '0.1.0';
+import { appVersion } from './util/app-version.js';
 
 function desktopId(display: number) {
   return `desk-${display}`;
@@ -235,7 +234,7 @@ export function buildApp() {
   app.get('/health', async () => {
     return {
       ok: true,
-      version: VERSION,
+      version: appVersion,
       uptimeSec: Math.floor(process.uptime())
     };
   });

--- a/src/util/app-version.ts
+++ b/src/util/app-version.ts
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+
+type PackageJson = {
+  version?: string;
+};
+
+function loadAppVersion() {
+  try {
+    const packageJsonUrl = new URL('../../package.json', import.meta.url);
+    const raw = fs.readFileSync(packageJsonUrl, 'utf8');
+    const parsed = JSON.parse(raw) as PackageJson;
+    return parsed.version ?? '0.0.0-dev';
+  } catch {
+    return '0.0.0-dev';
+  }
+}
+
+export const appVersion = loadAppVersion();

--- a/test/unit/app-version.test.ts
+++ b/test/unit/app-version.test.ts
@@ -1,0 +1,9 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { appVersion } from '../../src/util/app-version.ts';
+import packageJson from '../../package.json' with { type: 'json' };
+
+test('appVersion matches package.json version', () => {
+  assert.equal(appVersion, packageJson.version);
+});


### PR DESCRIPTION
## Summary
- add a Linux release packaging script and host install script
- add a publish GitHub Actions workflow for versioned release artifacts
- read the runtime version from package metadata and document release-based deployment

## Verification
- npm run build
- npm test
- npm run prettier
- npm run package:release -- 0.1.0-test

## Notes
- `npm run lint` still reports existing `no-console` warnings in the CLI files, but no lint errors were introduced by this change.