### PR TITLE
Add auth-gated desktop routes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,14 @@ AADM_PORT=8899
 # Optional auth. If set, requests must send: Authorization: Bearer <token>
 AADM_AUTH_TOKEN=
 
+# Optional route protection for externally exposed desktop routes.
+# `none` keeps current behavior. `auth_request` requires a verifier URL.
+AADM_DESKTOP_ROUTE_AUTH_MODE=none
+AADM_DESKTOP_ROUTE_AUTH_REQUEST_URL=
+# Comma-separated request headers to forward to the auth verifier, for example:
+# AADM_DESKTOP_ROUTE_AUTH_REQUEST_HEADERS=x-auth-request-user,x-orchestrator-token
+AADM_DESKTOP_ROUTE_AUTH_REQUEST_HEADERS=
+
 # Public base URL used to generate noVNC links (what YOU open in your browser)
 # Example: https://mybox.example.com
 AADM_PUBLIC_BASE_URL=https://host.example.com

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ infra/smoke-test/.terraform/
 infra/smoke-test/.runtime/
 infra/smoke-test/*.tfstate
 infra/smoke-test/*.tfstate.*
+infra/ansible/roles/
 tasks/
 .ballast/

--- a/README.md
+++ b/README.md
@@ -79,6 +79,34 @@ Default:
 - nginx snippet dir: `/etc/nginx/conf.d/agent-desktops`
 - route template: `/desktop/{display}/`
 - state dir: `./data`
+- route auth mode: `none`
+
+### Protected desktop routes
+
+For localhost-only development, leave route auth disabled.
+
+For externally exposed desktops, enable nginx `auth_request` verification:
+
+```bash
+AADM_DESKTOP_ROUTE_AUTH_MODE=auth_request
+AADM_DESKTOP_ROUTE_AUTH_REQUEST_URL=http://127.0.0.1:3001/verify
+AADM_DESKTOP_ROUTE_AUTH_REQUEST_HEADERS=x-auth-request-user,x-orchestrator-token
+```
+
+`AADM_DESKTOP_ROUTE_AUTH_REQUEST_URL` should point at an HTTP verifier that returns:
+
+- `2xx` to allow access
+- `401` or `403` to deny access
+- `5xx` if verification infrastructure fails
+
+The manager always forwards:
+
+- `X-Original-URI`
+- `X-Original-Method`
+- `X-Forwarded-Host`
+- `X-Forwarded-Proto`
+
+It also forwards any request headers listed in `AADM_DESKTOP_ROUTE_AUTH_REQUEST_HEADERS`.
 
 ---
 
@@ -119,6 +147,8 @@ location /desktop/3/ {
 ```
 
 The manager writes that snippet, runs `nginx -t`, then reloads Nginx.
+
+When route protection is enabled, each desktop snippet also includes an internal auth verifier location plus `auth_request` directives on the desktop locations.
 
 ---
 
@@ -233,6 +263,20 @@ curl -sX POST http://127.0.0.1:8899/v1/desktops \
   -d '{ "owner":"codex", "label":"issue-123", "ttlMinutes":120, "startUrl":"https://example.com" }' | jq
 ```
 
+To opt a desktop into route protection explicitly:
+
+```bash
+curl -sX POST http://127.0.0.1:8899/v1/desktops \
+  -H 'content-type: application/json' \
+  -d '{ "owner":"codex", "label":"protected", "routeAuthMode":"auth_request" }' | jq
+```
+
+`routeAuthMode` supports:
+
+- `inherit` to use the deployment default
+- `none` to force an open route
+- `auth_request` to require the configured verifier
+
 ### List
 
 ```bash
@@ -249,7 +293,9 @@ Doctor reports:
 
 - systemd status for VNC/websockify/chrome/aab
 - Nginx snippet path + existence
+- whether the generated desktop route is protected
 - port checks for VNC/websockify/CDP/AAB
+- effective route auth configuration for that desktop
 
 ### Destroy
 

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 inventory = ./inventory.ini
+roles_path = ./roles:~/.ansible/roles:/usr/share/ansible/roles:/etc/ansible/roles
 host_key_checking = False
 interpreter_python = auto_silent
 local_tmp = /tmp/.ansible-local

--- a/infra/ansible/playbooks/aadm_smoke.yml
+++ b/infra/ansible/playbooks/aadm_smoke.yml
@@ -395,21 +395,21 @@
     - name: Wait for smoke desktop websockify port
       ansible.builtin.wait_for:
         host: 127.0.0.1
-        port: "{{ 6080 + (aadm_create.json.display | int) }}"
+        port: '{{ 6080 + (aadm_create.json.display | int) }}'
         timeout: 30
       when: aadm_smoke_create_desktop
 
     - name: Wait for smoke desktop CDP port
       ansible.builtin.wait_for:
         host: 127.0.0.1
-        port: "{{ 9221 + (aadm_create.json.display | int) }}"
+        port: '{{ 9221 + (aadm_create.json.display | int) }}'
         timeout: 30
       when: aadm_smoke_create_desktop
 
     - name: Wait for smoke desktop aab port
       ansible.builtin.wait_for:
         host: 127.0.0.1
-        port: "{{ 8764 + (aadm_create.json.display | int) }}"
+        port: '{{ 8764 + (aadm_create.json.display | int) }}'
         timeout: 30
       when: aadm_smoke_create_desktop
 

--- a/infra/ansible/playbooks/aadm_smoke.yml
+++ b/infra/ansible/playbooks/aadm_smoke.yml
@@ -17,6 +17,8 @@
     aadm_auth_token: ''
     aadm_npm_global_bin: /usr/local/bin
     aadm_npm_package: ai-agent-browser
+    aadm_node_bin: /usr/bin/node
+    aadm_npm_bin: /usr/bin/npm
     aadm_smoke_create_desktop: true
     aadm_smoke_destroy_desktop: false
   tasks:
@@ -202,25 +204,25 @@
 
     - name: Install npm dependencies
       ansible.builtin.command:
-        cmd: npm install
+        cmd: '{{ aadm_npm_bin }} install'
         chdir: '{{ aadm_install_dir }}'
       become_user: '{{ aadm_service_user }}'
 
     - name: Install ai-agent-browser npm dependencies
       ansible.builtin.command:
-        cmd: npm install
+        cmd: '{{ aadm_npm_bin }} install'
         chdir: '{{ aab_install_dir }}'
       become_user: '{{ aadm_service_user }}'
 
     - name: Build manager
       ansible.builtin.command:
-        cmd: npm run build
+        cmd: '{{ aadm_npm_bin }} run build'
         chdir: '{{ aadm_install_dir }}'
       become_user: '{{ aadm_service_user }}'
 
     - name: Build ai-agent-browser
       ansible.builtin.command:
-        cmd: npm run build
+        cmd: '{{ aadm_npm_bin }} run build'
         chdir: '{{ aab_install_dir }}'
       become_user: '{{ aadm_service_user }}'
 
@@ -232,7 +234,7 @@
         mode: '0755'
         content: |
           #!/usr/bin/env bash
-          exec /usr/bin/env node /opt/ai-agent-desktop-manager/dist/cli/aadm.js "$@"
+          exec {{ aadm_node_bin }} /opt/ai-agent-desktop-manager/dist/cli/aadm.js "$@"
 
     - name: Install global aab-console CLI wrapper
       ansible.builtin.copy:
@@ -242,7 +244,7 @@
         mode: '0755'
         content: |
           #!/usr/bin/env bash
-          exec /usr/bin/env node /opt/ai-agent-desktop-manager/dist/cli/aab-console.js "$@"
+          exec {{ aadm_node_bin }} /opt/ai-agent-desktop-manager/dist/cli/aab-console.js "$@"
 
     - name: Install global ai-agent-browser CLI wrapper
       ansible.builtin.copy:
@@ -252,7 +254,7 @@
         mode: '0755'
         content: |
           #!/usr/bin/env bash
-          exec /usr/bin/env node /opt/ai-agent-browser/dist/index.js "$@"
+          exec {{ aadm_node_bin }} /opt/ai-agent-browser/dist/index.js "$@"
 
     - name: Install global aab CLI wrapper
       ansible.builtin.copy:
@@ -262,7 +264,7 @@
         mode: '0755'
         content: |
           #!/usr/bin/env bash
-          exec /usr/bin/env node /opt/ai-agent-browser/dist/index.js "$@"
+          exec {{ aadm_node_bin }} /opt/ai-agent-browser/dist/index.js "$@"
 
     - name: Ensure nginx snippet directory exists
       ansible.builtin.file:

--- a/infra/ansible/playbooks/aadm_smoke.yml
+++ b/infra/ansible/playbooks/aadm_smoke.yml
@@ -17,8 +17,6 @@
     aadm_auth_token: ''
     aadm_npm_global_bin: /usr/local/bin
     aadm_npm_package: ai-agent-browser
-    aadm_node_bin: /usr/bin/node
-    aadm_npm_bin: /usr/bin/npm
     aadm_smoke_create_desktop: true
     aadm_smoke_destroy_desktop: false
   tasks:
@@ -88,6 +86,34 @@
       ansible.builtin.apt:
         name: nodejs
         update_cache: true
+
+    - name: Install npm
+      ansible.builtin.apt:
+        name: npm
+        update_cache: true
+
+    - name: Detect node binary path
+      ansible.builtin.shell: |
+        set -euo pipefail
+        command -v node
+      args:
+        executable: /bin/bash
+      register: aadm_node_path
+      changed_when: false
+
+    - name: Detect npm binary path
+      ansible.builtin.shell: |
+        set -euo pipefail
+        command -v npm
+      args:
+        executable: /bin/bash
+      register: aadm_npm_path
+      changed_when: false
+
+    - name: Record node and npm binary paths
+      ansible.builtin.set_fact:
+        aadm_node_bin: '{{ aadm_node_path.stdout }}'
+        aadm_npm_bin: '{{ aadm_npm_path.stdout }}'
 
     - name: Install Google Chrome signing key
       ansible.builtin.get_url:

--- a/infra/ansible/playbooks/aadm_smoke.yml
+++ b/infra/ansible/playbooks/aadm_smoke.yml
@@ -375,6 +375,7 @@
       ansible.builtin.command:
         cmd: systemctl reset-failed aadm.service vnc@1 websockify@1 chrome@1 aab@1
       changed_when: false
+      failed_when: false
 
     - name: Enable and start manager
       ansible.builtin.systemd:

--- a/infra/ansible/playbooks/aadm_smoke.yml
+++ b/infra/ansible/playbooks/aadm_smoke.yml
@@ -85,6 +85,7 @@
     - name: Install Node.js
       ansible.builtin.apt:
         name: nodejs
+        state: latest
         update_cache: true
 
     - name: Install npm
@@ -114,6 +115,13 @@
       ansible.builtin.set_fact:
         aadm_node_bin: '{{ aadm_node_path.stdout }}'
         aadm_npm_bin: '{{ aadm_npm_path.stdout }}'
+
+    - name: Verify Node 22 is installed
+      ansible.builtin.command:
+        cmd: '{{ aadm_node_bin }} --version'
+      register: aadm_node_version
+      changed_when: false
+      failed_when: not (aadm_node_version.stdout is match("^v22\\."))
 
     - name: Install Google Chrome signing key
       ansible.builtin.get_url:
@@ -406,6 +414,27 @@
         return_content: true
         status_code: 200
       register: aadm_create
+      when: aadm_smoke_create_desktop
+
+    - name: Wait for smoke desktop websockify port
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: "{{ 6080 + (aadm_create.json.display | int) }}"
+        timeout: 30
+      when: aadm_smoke_create_desktop
+
+    - name: Wait for smoke desktop CDP port
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: "{{ 9221 + (aadm_create.json.display | int) }}"
+        timeout: 30
+      when: aadm_smoke_create_desktop
+
+    - name: Wait for smoke desktop aab port
+      ansible.builtin.wait_for:
+        host: 127.0.0.1
+        port: "{{ 8764 + (aadm_create.json.display | int) }}"
+        timeout: 30
       when: aadm_smoke_create_desktop
 
     - name: Run doctor on smoke desktop

--- a/infra/ansible/playbooks/aadm_smoke.yml
+++ b/infra/ansible/playbooks/aadm_smoke.yml
@@ -2,6 +2,10 @@
 - name: Provision ai-agent-desktop-manager smoke test host
   hosts: all
   become: true
+  roles:
+    - role: geerlingguy.nodejs
+      vars:
+        nodejs_version: '22.x'
   vars:
     aadm_service_user: aadm
     aadm_service_group: aadm
@@ -61,36 +65,6 @@
           - xauth
           - xfonts-base
           - xterm
-        update_cache: true
-
-    - name: Install NodeSource GPG key
-      ansible.builtin.get_url:
-        url: https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key
-        dest: /tmp/nodesource.gpg.key
-        mode: '0644'
-
-    - name: Dearmor NodeSource GPG key
-      ansible.builtin.command:
-        cmd: gpg --dearmor -o /usr/share/keyrings/nodesource.gpg /tmp/nodesource.gpg.key
-      args:
-        creates: /usr/share/keyrings/nodesource.gpg
-
-    - name: Configure NodeSource repository
-      ansible.builtin.copy:
-        dest: /etc/apt/sources.list.d/nodesource.list
-        mode: '0644'
-        content: |
-          deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_22.x nodistro main
-
-    - name: Install Node.js
-      ansible.builtin.apt:
-        name: nodejs
-        state: latest
-        update_cache: true
-
-    - name: Install npm
-      ansible.builtin.apt:
-        name: npm
         update_cache: true
 
     - name: Detect node binary path

--- a/infra/ansible/playbooks/aadm_smoke.yml
+++ b/infra/ansible/playbooks/aadm_smoke.yml
@@ -2,10 +2,6 @@
 - name: Provision ai-agent-desktop-manager smoke test host
   hosts: all
   become: true
-  roles:
-    - role: geerlingguy.nodejs
-      vars:
-        nodejs_version: '22.x'
   vars:
     aadm_service_user: aadm
     aadm_service_group: aadm
@@ -42,6 +38,12 @@
       args:
         executable: /bin/bash
       changed_when: false
+
+    - name: Install Node.js 22 with geerlingguy.nodejs
+      ansible.builtin.include_role:
+        name: geerlingguy.nodejs
+      vars:
+        nodejs_version: '22.x'
 
     - name: Ensure apt prerequisites are present
       ansible.builtin.apt:

--- a/infra/ansible/requirements.yml
+++ b/infra/ansible/requirements.yml
@@ -1,4 +1,6 @@
 ---
 roles:
   - name: geerlingguy.nodejs
-    version: 7.1.3
+    src: https://github.com/geerlingguy/ansible-role-nodejs.git
+    scm: git
+    version: master

--- a/infra/ansible/requirements.yml
+++ b/infra/ansible/requirements.yml
@@ -3,4 +3,4 @@ roles:
   - name: geerlingguy.nodejs
     src: https://github.com/geerlingguy/ansible-role-nodejs.git
     scm: git
-    version: master
+    version: 7.1.0

--- a/infra/ansible/requirements.yml
+++ b/infra/ansible/requirements.yml
@@ -1,0 +1,4 @@
+---
+roles:
+  - name: geerlingguy.nodejs
+    version: 7.1.3

--- a/scripts/ec2-smoke-test.sh
+++ b/scripts/ec2-smoke-test.sh
@@ -6,6 +6,7 @@ TF_DIR="$ROOT_DIR/infra/smoke-test"
 ANSIBLE_DIR="$ROOT_DIR/infra/ansible"
 PLAYBOOK="$ANSIBLE_DIR/playbooks/aadm_smoke.yml"
 ANSIBLE_REQUIREMENTS="$ANSIBLE_DIR/requirements.yml"
+ANSIBLE_ROLES_DIR="$ANSIBLE_DIR/roles"
 RUNTIME_DIR="$TF_DIR/.runtime"
 KEY_PATH="$RUNTIME_DIR/id_ed25519"
 ARCHIVE_PATH="$RUNTIME_DIR/repo.tgz"
@@ -283,7 +284,9 @@ run_ansible() {
 
   write_inventory "$host"
 
-  ansible-galaxy role install -r "$ANSIBLE_REQUIREMENTS"
+  mkdir -p "$ANSIBLE_ROLES_DIR"
+  ANSIBLE_CONFIG="$ANSIBLE_DIR/ansible.cfg" \
+  ansible-galaxy role install -r "$ANSIBLE_REQUIREMENTS" -p "$ANSIBLE_ROLES_DIR"
 
   ANSIBLE_CONFIG="$ANSIBLE_DIR/ansible.cfg" \
   ansible-playbook \

--- a/scripts/ec2-smoke-test.sh
+++ b/scripts/ec2-smoke-test.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TF_DIR="$ROOT_DIR/infra/smoke-test"
 ANSIBLE_DIR="$ROOT_DIR/infra/ansible"
 PLAYBOOK="$ANSIBLE_DIR/playbooks/aadm_smoke.yml"
+ANSIBLE_REQUIREMENTS="$ANSIBLE_DIR/requirements.yml"
 RUNTIME_DIR="$TF_DIR/.runtime"
 KEY_PATH="$RUNTIME_DIR/id_ed25519"
 ARCHIVE_PATH="$RUNTIME_DIR/repo.tgz"
@@ -40,10 +41,10 @@ Options:
   -h, --help                   Show this help
 
 Examples:
-  $(basename "$0") run --region us-west-2
-  $(basename "$0") run --region us-west-2 --destroy-on-success
-  $(basename "$0") ssh --region us-west-2
-  $(basename "$0") destroy --region us-west-2
+  $(basename "$0") run --region us-west-1
+  $(basename "$0") run --region us-west-1 --destroy-on-success
+  $(basename "$0") ssh --region us-west-1
+  $(basename "$0") destroy --region us-west-1
 EOF
 }
 
@@ -61,7 +62,7 @@ Missing required --region argument.
 
 Example:
 
-  ./scripts/ec2-smoke-test.sh run --region us-west-2
+  ./scripts/ec2-smoke-test.sh run --region us-west-1
 EOF
     exit 1
   fi
@@ -282,6 +283,8 @@ run_ansible() {
 
   write_inventory "$host"
 
+  ansible-galaxy role install -r "$ANSIBLE_REQUIREMENTS"
+
   ANSIBLE_CONFIG="$ANSIBLE_DIR/ansible.cfg" \
   ansible-playbook \
     -i "$INVENTORY_PATH" \
@@ -321,6 +324,7 @@ run() {
   require_cmd tar
   require_cmd terraform
   require_cmd ansible-playbook
+  require_cmd ansible-galaxy
 
   require_region
   ensure_runtime_dir

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,8 +1,10 @@
 import { z } from 'zod';
+import { RouteAuthRequestModeSchema } from '../util/route-auth.js';
 
 export const CreateDesktopBody = z.object({
   owner: z.string().optional(),
   label: z.string().optional(),
   ttlMinutes: z.number().int().positive().optional(),
-  startUrl: z.string().url().optional()
+  startUrl: z.string().url().optional(),
+  routeAuthMode: RouteAuthRequestModeSchema.optional()
 });

--- a/src/server.ts
+++ b/src/server.ts
@@ -32,6 +32,7 @@ import {
 import { CreateDesktopBody } from './api/types.js';
 import { isPortOpen } from './util/net.js';
 import { appVersion } from './util/app-version.js';
+import { resolveDesktopRouteAuth } from './util/route-auth.js';
 
 function desktopId(display: number) {
   return `desk-${display}`;
@@ -156,14 +157,19 @@ async function removeSnippetAndReload(
 }
 
 async function restoreSnippetAndReload(
-  desktop: Pick<DesktopRecord, 'id' | 'display' | 'wsPort'>,
+  desktop: Pick<DesktopRecord, 'id' | 'display' | 'wsPort' | 'routeAuth'>,
   log: { warn: (obj: unknown, msg: string) => void }
 ) {
   const issues: string[] = [];
   try {
     await writeSnippet(
       desktop.id,
-      buildSnippet(desktop.display, desktop.wsPort)
+      buildSnippet(
+        desktop.id,
+        desktop.display,
+        desktop.wsPort,
+        desktop.routeAuth
+      )
     );
     const testRes = await nginxTest();
     if (!testRes.ok) {
@@ -274,6 +280,16 @@ export function buildApp() {
 
       const novncUrl = novncUrlFor(alloc.display);
       const aabUrl = aabUrlFor(alloc.aabPort);
+      let routeAuth;
+      try {
+        routeAuth = resolveDesktopRouteAuth(config, parsed.data.routeAuthMode);
+      } catch (e) {
+        return reply.code(500).send({
+          ok: false,
+          error: 'route_auth_config_invalid',
+          details: String((e as Error)?.message ?? e)
+        });
+      }
 
       const record: DesktopRecord = {
         id,
@@ -290,7 +306,8 @@ export function buildApp() {
         aabPort: alloc.aabPort,
         novncUrl,
         aabUrl,
-        startUrl: parsed.data.startUrl
+        startUrl: parsed.data.startUrl,
+        routeAuth
       };
 
       // 1) start units
@@ -307,7 +324,12 @@ export function buildApp() {
       // 2) write nginx snippet
       let snippetWritten = false;
       try {
-        const snippet = buildSnippet(alloc.display, alloc.wsPort);
+        const snippet = buildSnippet(
+          id,
+          alloc.display,
+          alloc.wsPort,
+          routeAuth
+        );
         await writeSnippet(id, snippet);
         snippetWritten = true;
 
@@ -364,7 +386,8 @@ export function buildApp() {
         novncUrl: record.novncUrl,
         aabUrl: record.aabUrl,
         cdp: { host: '127.0.0.1', port: record.cdpPort },
-        status: record.status
+        status: record.status,
+        routeAuth: record.routeAuth
       };
     });
   });
@@ -480,7 +503,8 @@ export function buildApp() {
         aab: aabPortOpen
       },
       nginx: {
-        snippetExists
+        snippetExists,
+        protected: d.routeAuth.mode !== 'none'
       }
     };
 
@@ -496,6 +520,7 @@ export function buildApp() {
         checks.ports.aab &&
         checks.nginx.snippetExists,
       desktop: d,
+      routeAuth: d.routeAuth,
       checks,
       systemd: {
         vnc: {

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import dotenv from 'dotenv';
 import path from 'node:path';
+import {
+  RouteAuthModeSchema,
+  parseForwardedHeaderNames
+} from './route-auth.js';
 
 dotenv.config();
 
@@ -17,6 +21,9 @@ export const Config = z.object({
   port: z.number().int().default(8899),
 
   authToken: z.string().optional(),
+  desktopRouteAuthMode: RouteAuthModeSchema.default('none'),
+  desktopRouteAuthRequestUrl: z.string().url().optional(),
+  desktopRouteAuthRequestHeaders: z.array(z.string()).default([]),
 
   publicBaseUrl: z.string().url().default('https://host.example.com'),
 
@@ -50,6 +57,13 @@ export const config = Config.parse({
   port: intFromEnv('AADM_PORT', 8899),
 
   authToken: process.env.AADM_AUTH_TOKEN || undefined,
+  desktopRouteAuthMode:
+    process.env.AADM_DESKTOP_ROUTE_AUTH_MODE ?? 'none',
+  desktopRouteAuthRequestUrl:
+    process.env.AADM_DESKTOP_ROUTE_AUTH_REQUEST_URL || undefined,
+  desktopRouteAuthRequestHeaders: parseForwardedHeaderNames(
+    process.env.AADM_DESKTOP_ROUTE_AUTH_REQUEST_HEADERS
+  ),
 
   publicBaseUrl: process.env.AADM_PUBLIC_BASE_URL ?? 'https://host.example.com',
 
@@ -109,6 +123,15 @@ function validateConfig() {
   if (aabNeededMax > config.aabPortMax) {
     throw new Error(
       `invalid_config:aab_range_too_small (need max >= ${aabNeededMax}, got ${config.aabPortMax})`
+    );
+  }
+
+  if (
+    config.desktopRouteAuthMode === 'auth_request' &&
+    !config.desktopRouteAuthRequestUrl
+  ) {
+    throw new Error(
+      'invalid_config:desktop_route_auth_request_url_required'
     );
   }
 }

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -57,8 +57,7 @@ export const config = Config.parse({
   port: intFromEnv('AADM_PORT', 8899),
 
   authToken: process.env.AADM_AUTH_TOKEN || undefined,
-  desktopRouteAuthMode:
-    process.env.AADM_DESKTOP_ROUTE_AUTH_MODE ?? 'none',
+  desktopRouteAuthMode: process.env.AADM_DESKTOP_ROUTE_AUTH_MODE ?? 'none',
   desktopRouteAuthRequestUrl:
     process.env.AADM_DESKTOP_ROUTE_AUTH_REQUEST_URL || undefined,
   desktopRouteAuthRequestHeaders: parseForwardedHeaderNames(
@@ -130,9 +129,7 @@ function validateConfig() {
     config.desktopRouteAuthMode === 'auth_request' &&
     !config.desktopRouteAuthRequestUrl
   ) {
-    throw new Error(
-      'invalid_config:desktop_route_auth_request_url_required'
-    );
+    throw new Error('invalid_config:desktop_route_auth_request_url_required');
   }
 }
 

--- a/src/util/nginx.ts
+++ b/src/util/nginx.ts
@@ -2,7 +2,11 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { config } from './config.js';
 import { execCmd } from './exec.js';
-import type { DesktopRouteAuth } from './route-auth.js';
+import {
+  normalizeAuthRequestUrl,
+  normalizeForwardedHeaderName,
+  type DesktopRouteAuth
+} from './route-auth.js';
 
 export function snippetFilename(desktopId: string) {
   return path.join(config.nginxSnippetDir, `${desktopId}.conf`);
@@ -20,7 +24,14 @@ function buildAuthRequestBlock(
   desktopId: string,
   routeAuth: Extract<DesktopRouteAuth, { mode: 'auth_request' }>
 ) {
+  const normalizedUrl = normalizeAuthRequestUrl(routeAuth.authRequest.url);
+  if (!normalizedUrl) {
+    throw new Error('invalid_route_auth:auth_request_url');
+  }
+
   const forwardedHeaders = routeAuth.authRequest.forwardedHeaders
+    .map((headerName) => normalizeForwardedHeaderName(headerName))
+    .filter((headerName): headerName is string => Boolean(headerName))
     .map(
       (headerName) =>
         `  proxy_set_header ${headerName} ${headerNameToNginxVariable(headerName)};`
@@ -29,7 +40,7 @@ function buildAuthRequestBlock(
 
   return `location = ${authRequestLocation(desktopId)} {
   internal;
-  proxy_pass ${routeAuth.authRequest.url};
+  proxy_pass ${normalizedUrl};
   proxy_pass_request_body off;
   proxy_set_header Content-Length "";
   proxy_set_header X-Original-URI $request_uri;

--- a/src/util/nginx.ts
+++ b/src/util/nginx.ts
@@ -54,12 +54,27 @@ export function buildSnippet(
       ? `  auth_request ${authRequestLocation(desktopId)};\n`
       : '';
   // Redirect the bare desktop path to noVNC's HTML entrypoint.
-  // Trailing slash in proxy_pass avoids path issues with noVNC assets.
-  return `${routeAuth.mode === 'auth_request' ? buildAuthRequestBlock(desktopId, routeAuth) : ''}location = ${loc} {
-${authLine}  return 302 ${loc}vnc.html?${query};
+  // Protected routes proxy directly to vnc.html so auth_request runs on the entry request.
+  const entryLocation =
+    routeAuth.mode === 'auth_request'
+      ? `location = ${loc} {
+${authLine}  proxy_pass http://127.0.0.1:${wsPort}/vnc.html?${query};
+  proxy_http_version 1.1;
+  proxy_set_header Upgrade $http_upgrade;
+  proxy_set_header Connection "upgrade";
+  proxy_read_timeout 7d;
+  proxy_send_timeout 7d;
 }
 
-location ${loc} {
+`
+      : `location = ${loc} {
+  return 302 ${loc}vnc.html?${query};
+}
+
+`;
+
+  // Trailing slash in proxy_pass avoids path issues with noVNC assets.
+  return `${routeAuth.mode === 'auth_request' ? buildAuthRequestBlock(desktopId, routeAuth) : ''}${entryLocation}location ${loc} {
 ${authLine}  proxy_pass http://127.0.0.1:${wsPort}/;
   proxy_http_version 1.1;
   proxy_set_header Upgrade $http_upgrade;

--- a/src/util/nginx.ts
+++ b/src/util/nginx.ts
@@ -2,23 +2,65 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import { config } from './config.js';
 import { execCmd } from './exec.js';
+import type { DesktopRouteAuth } from './route-auth.js';
 
 export function snippetFilename(desktopId: string) {
   return path.join(config.nginxSnippetDir, `${desktopId}.conf`);
 }
 
-export function buildSnippet(display: number, wsPort: number) {
+function headerNameToNginxVariable(headerName: string) {
+  return `$http_${headerName.toLowerCase().replace(/-/g, '_')}`;
+}
+
+function authRequestLocation(desktopId: string) {
+  return `/_aadm/auth/${desktopId}`;
+}
+
+function buildAuthRequestBlock(
+  desktopId: string,
+  routeAuth: Extract<DesktopRouteAuth, { mode: 'auth_request' }>
+) {
+  const forwardedHeaders = routeAuth.authRequest.forwardedHeaders
+    .map(
+      (headerName) =>
+        `  proxy_set_header ${headerName} ${headerNameToNginxVariable(headerName)};`
+    )
+    .join('\n');
+
+  return `location = ${authRequestLocation(desktopId)} {
+  internal;
+  proxy_pass ${routeAuth.authRequest.url};
+  proxy_pass_request_body off;
+  proxy_set_header Content-Length "";
+  proxy_set_header X-Original-URI $request_uri;
+  proxy_set_header X-Original-Method $request_method;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Proto $scheme;
+${forwardedHeaders ? `${forwardedHeaders}\n` : ''}}
+`;
+}
+
+export function buildSnippet(
+  desktopId: string,
+  display: number,
+  wsPort: number,
+  routeAuth: DesktopRouteAuth = { mode: 'none' }
+) {
   const prefix = config.novncPathPrefix.replace(/\/$/, '');
   const loc = `${prefix}/${display}/`;
   const query = `path=${prefix.replace(/^\//, '')}/${display}/websockify&resize=remote&autoconnect=1`;
+  const authLine =
+    routeAuth.mode === 'auth_request'
+      ? `  auth_request ${authRequestLocation(desktopId)};\n`
+      : '';
   // Redirect the bare desktop path to noVNC's HTML entrypoint.
   // Trailing slash in proxy_pass avoids path issues with noVNC assets.
-  return `location = ${loc} {
-  return 302 ${loc}vnc.html?${query};
+  return `${routeAuth.mode === 'auth_request' ? buildAuthRequestBlock(desktopId, routeAuth) : ''}location = ${loc} {
+${authLine}  return 302 ${loc}vnc.html?${query};
 }
 
 location ${loc} {
-  proxy_pass http://127.0.0.1:${wsPort}/;
+${authLine}  proxy_pass http://127.0.0.1:${wsPort}/;
   proxy_http_version 1.1;
   proxy_set_header Upgrade $http_upgrade;
   proxy_set_header Connection "upgrade";

--- a/src/util/route-auth.ts
+++ b/src/util/route-auth.ts
@@ -56,9 +56,12 @@ export function normalizeDesktopRouteAuth(
     const url = candidate.authRequest?.url;
     if (typeof url !== 'string' || !url) return undefined;
 
-    const forwardedHeaders = Array.isArray(candidate.authRequest?.forwardedHeaders)
+    const forwardedHeaders = Array.isArray(
+      candidate.authRequest?.forwardedHeaders
+    )
       ? candidate.authRequest.forwardedHeaders.filter(
-          (header): header is string => typeof header === 'string' && header.length > 0
+          (header): header is string =>
+            typeof header === 'string' && header.length > 0
         )
       : [];
 
@@ -83,9 +86,7 @@ export function defaultDesktopRouteAuth(
 ): DesktopRouteAuth {
   if (routeAuthConfig.desktopRouteAuthMode === 'auth_request') {
     if (!routeAuthConfig.desktopRouteAuthRequestUrl) {
-      throw new Error(
-        'invalid_config:desktop_route_auth_request_url_required'
-      );
+      throw new Error('invalid_config:desktop_route_auth_request_url_required');
     }
 
     return {

--- a/src/util/route-auth.ts
+++ b/src/util/route-auth.ts
@@ -26,20 +26,60 @@ export type RouteAuthConfig = {
   desktopRouteAuthRequestHeaders: string[];
 };
 
+const SAFE_HEADER_NAME = /^[A-Za-z0-9-]+$/;
+
+function hasUnsafeNginxDirectiveChars(value: string) {
+  for (const char of value) {
+    if (/\s/.test(char) || char === ';' || char === '{' || char === '}') {
+      return true;
+    }
+
+    const code = char.charCodeAt(0);
+    if (code <= 0x1f || code === 0x7f) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function uniqueStrings(values: string[]) {
   return [...new Set(values)];
+}
+
+export function normalizeForwardedHeaderName(value: string) {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized || !SAFE_HEADER_NAME.test(normalized)) return undefined;
+  return normalized;
+}
+
+export function sanitizeForwardedHeaderNames(values: string[]) {
+  return uniqueStrings(
+    values
+      .map((value) => normalizeForwardedHeaderName(value))
+      .filter((value): value is string => Boolean(value))
+  );
 }
 
 export function parseForwardedHeaderNames(raw: string | undefined) {
   if (!raw) return [];
 
-  return uniqueStrings(
-    raw
-      .split(',')
-      .map((value) => value.trim())
-      .filter(Boolean)
-      .map((value) => value.toLowerCase())
-  );
+  return sanitizeForwardedHeaderNames(raw.split(','));
+}
+
+export function normalizeAuthRequestUrl(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed || hasUnsafeNginxDirectiveChars(trimmed)) return undefined;
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return undefined;
+    }
+    return parsed.toString();
+  } catch {
+    return undefined;
+  }
 }
 
 export function normalizeDesktopRouteAuth(
@@ -64,12 +104,14 @@ export function normalizeDesktopRouteAuth(
             typeof header === 'string' && header.length > 0
         )
       : [];
+    const normalizedUrl = normalizeAuthRequestUrl(url);
+    if (!normalizedUrl) return undefined;
 
     return {
       mode: 'auth_request',
       authRequest: {
-        url,
-        forwardedHeaders: uniqueStrings(forwardedHeaders)
+        url: normalizedUrl,
+        forwardedHeaders: sanitizeForwardedHeaderNames(forwardedHeaders)
       }
     };
   }
@@ -85,15 +127,20 @@ export function defaultDesktopRouteAuth(
   routeAuthConfig: RouteAuthConfig
 ): DesktopRouteAuth {
   if (routeAuthConfig.desktopRouteAuthMode === 'auth_request') {
-    if (!routeAuthConfig.desktopRouteAuthRequestUrl) {
+    const normalizedUrl = routeAuthConfig.desktopRouteAuthRequestUrl
+      ? normalizeAuthRequestUrl(routeAuthConfig.desktopRouteAuthRequestUrl)
+      : undefined;
+    if (!normalizedUrl) {
       throw new Error('invalid_config:desktop_route_auth_request_url_required');
     }
 
     return {
       mode: 'auth_request',
       authRequest: {
-        url: routeAuthConfig.desktopRouteAuthRequestUrl,
-        forwardedHeaders: routeAuthConfig.desktopRouteAuthRequestHeaders
+        url: normalizedUrl,
+        forwardedHeaders: sanitizeForwardedHeaderNames(
+          routeAuthConfig.desktopRouteAuthRequestHeaders
+        )
       }
     };
   }
@@ -113,15 +160,20 @@ export function resolveDesktopRouteAuth(
     return { mode: 'none' };
   }
 
-  if (!routeAuthConfig.desktopRouteAuthRequestUrl) {
+  const normalizedUrl = routeAuthConfig.desktopRouteAuthRequestUrl
+    ? normalizeAuthRequestUrl(routeAuthConfig.desktopRouteAuthRequestUrl)
+    : undefined;
+  if (!normalizedUrl) {
     throw new Error('invalid_config:desktop_route_auth_request_url_required');
   }
 
   return {
     mode: 'auth_request',
     authRequest: {
-      url: routeAuthConfig.desktopRouteAuthRequestUrl,
-      forwardedHeaders: routeAuthConfig.desktopRouteAuthRequestHeaders
+      url: normalizedUrl,
+      forwardedHeaders: sanitizeForwardedHeaderNames(
+        routeAuthConfig.desktopRouteAuthRequestHeaders
+      )
     }
   };
 }

--- a/src/util/route-auth.ts
+++ b/src/util/route-auth.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+
+export const RouteAuthModeSchema = z.enum(['none', 'auth_request']);
+export type RouteAuthMode = z.infer<typeof RouteAuthModeSchema>;
+
+export const RouteAuthRequestModeSchema = z.enum([
+  'inherit',
+  'none',
+  'auth_request'
+]);
+export type RouteAuthRequestMode = z.infer<typeof RouteAuthRequestModeSchema>;
+
+export type DesktopRouteAuth =
+  | { mode: 'none' }
+  | {
+      mode: 'auth_request';
+      authRequest: {
+        url: string;
+        forwardedHeaders: string[];
+      };
+    };
+
+export type RouteAuthConfig = {
+  desktopRouteAuthMode: RouteAuthMode;
+  desktopRouteAuthRequestUrl?: string;
+  desktopRouteAuthRequestHeaders: string[];
+};
+
+function uniqueStrings(values: string[]) {
+  return [...new Set(values)];
+}
+
+export function parseForwardedHeaderNames(raw: string | undefined) {
+  if (!raw) return [];
+
+  return uniqueStrings(
+    raw
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .map((value) => value.toLowerCase())
+  );
+}
+
+export function normalizeDesktopRouteAuth(
+  value: unknown
+): DesktopRouteAuth | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+
+  const candidate = value as {
+    mode?: unknown;
+    authRequest?: { url?: unknown; forwardedHeaders?: unknown };
+  };
+
+  if (candidate.mode === 'auth_request') {
+    const url = candidate.authRequest?.url;
+    if (typeof url !== 'string' || !url) return undefined;
+
+    const forwardedHeaders = Array.isArray(candidate.authRequest?.forwardedHeaders)
+      ? candidate.authRequest.forwardedHeaders.filter(
+          (header): header is string => typeof header === 'string' && header.length > 0
+        )
+      : [];
+
+    return {
+      mode: 'auth_request',
+      authRequest: {
+        url,
+        forwardedHeaders: uniqueStrings(forwardedHeaders)
+      }
+    };
+  }
+
+  if (candidate.mode === 'none') {
+    return { mode: 'none' };
+  }
+
+  return undefined;
+}
+
+export function defaultDesktopRouteAuth(
+  routeAuthConfig: RouteAuthConfig
+): DesktopRouteAuth {
+  if (routeAuthConfig.desktopRouteAuthMode === 'auth_request') {
+    if (!routeAuthConfig.desktopRouteAuthRequestUrl) {
+      throw new Error(
+        'invalid_config:desktop_route_auth_request_url_required'
+      );
+    }
+
+    return {
+      mode: 'auth_request',
+      authRequest: {
+        url: routeAuthConfig.desktopRouteAuthRequestUrl,
+        forwardedHeaders: routeAuthConfig.desktopRouteAuthRequestHeaders
+      }
+    };
+  }
+
+  return { mode: 'none' };
+}
+
+export function resolveDesktopRouteAuth(
+  routeAuthConfig: RouteAuthConfig,
+  requestedMode?: RouteAuthRequestMode
+): DesktopRouteAuth {
+  if (!requestedMode || requestedMode === 'inherit') {
+    return defaultDesktopRouteAuth(routeAuthConfig);
+  }
+
+  if (requestedMode === 'none') {
+    return { mode: 'none' };
+  }
+
+  if (!routeAuthConfig.desktopRouteAuthRequestUrl) {
+    throw new Error('invalid_config:desktop_route_auth_request_url_required');
+  }
+
+  return {
+    mode: 'auth_request',
+    authRequest: {
+      url: routeAuthConfig.desktopRouteAuthRequestUrl,
+      forwardedHeaders: routeAuthConfig.desktopRouteAuthRequestHeaders
+    }
+  };
+}

--- a/src/util/store.ts
+++ b/src/util/store.ts
@@ -56,8 +56,9 @@ export async function loadState(): Promise<State> {
         (desktop): DesktopRecord =>
           ({
             ...(desktop as DesktopRecord),
-            routeAuth:
-              normalizeDesktopRouteAuth(desktop.routeAuth) ?? { mode: 'none' }
+            routeAuth: normalizeDesktopRouteAuth(desktop.routeAuth) ?? {
+              mode: 'none'
+            }
           }) as DesktopRecord
       )
     };

--- a/src/util/store.ts
+++ b/src/util/store.ts
@@ -1,6 +1,10 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { config } from './config.js';
+import {
+  normalizeDesktopRouteAuth,
+  type DesktopRouteAuth
+} from './route-auth.js';
 
 export type DesktopRecord = {
   id: string;
@@ -18,6 +22,7 @@ export type DesktopRecord = {
   novncUrl: string;
   aabUrl: string;
   startUrl?: string;
+  routeAuth: DesktopRouteAuth;
 };
 
 export type State = { desktops: DesktopRecord[] };
@@ -41,7 +46,21 @@ export async function loadState(): Promise<State> {
   try {
     const raw = await fs.readFile(statePath, 'utf-8');
     const parsed = JSON.parse(raw);
-    return { desktops: Array.isArray(parsed.desktops) ? parsed.desktops : [] };
+    const desktops: Array<Record<string, unknown>> = Array.isArray(
+      parsed.desktops
+    )
+      ? parsed.desktops
+      : [];
+    return {
+      desktops: desktops.map(
+        (desktop): DesktopRecord =>
+          ({
+            ...(desktop as DesktopRecord),
+            routeAuth:
+              normalizeDesktopRouteAuth(desktop.routeAuth) ?? { mode: 'none' }
+          }) as DesktopRecord
+      )
+    };
   } catch (e) {
     if ((e as NodeJS.ErrnoException)?.code === 'ENOENT')
       return { desktops: [] };

--- a/test/integration/server.test.ts
+++ b/test/integration/server.test.ts
@@ -24,6 +24,13 @@ async function importServerWithEnv() {
   const configMod = await import('../../src/util/config.ts');
   const netMod = await import('../../src/util/net.ts');
   configMod.config.authToken = 'test-token';
+  configMod.config.desktopRouteAuthMode = 'none';
+  configMod.config.desktopRouteAuthRequestUrl =
+    'http://127.0.0.1:3001/verify';
+  configMod.config.desktopRouteAuthRequestHeaders = [
+    'x-auth-request-user',
+    'x-orchestrator-token'
+  ];
   configMod.config.stateDir = stateDir;
   configMod.config.nginxSnippetDir = nginxDir;
   configMod.config.publicBaseUrl = 'https://host.example.com';
@@ -148,10 +155,62 @@ test(
     const body = doctor.json();
     assert.equal(body.ok, true);
     assert.equal(body.checks.nginx.snippetExists, true);
+    assert.equal(body.checks.nginx.protected, false);
     assert.equal(body.checks.ports.vnc, true);
     assert.equal(body.checks.ports.websockify, true);
     assert.equal(body.checks.ports.cdp, true);
     assert.equal(body.checks.ports.aab, true);
+    assert.deepEqual(body.routeAuth, { mode: 'none' });
+  }
+);
+
+test(
+  'create with auth_request route protection persists metadata and doctor reports it',
+  { concurrency: false },
+  async () => {
+    assert.ok(app);
+    calls = [];
+
+    const create = await app.inject({
+      method: 'POST',
+      url: '/v1/desktops',
+      headers: { ...authHeaders, 'content-type': 'application/json' },
+      payload: {
+        owner: 'codex',
+        label: 'protected',
+        routeAuthMode: 'auth_request'
+      }
+    });
+    assert.equal(create.statusCode, 200);
+    assert.deepEqual(create.json().routeAuth, {
+      mode: 'auth_request',
+      authRequest: {
+        url: 'http://127.0.0.1:3001/verify',
+        forwardedHeaders: ['x-auth-request-user', 'x-orchestrator-token']
+      }
+    });
+
+    const getDesktop = await app.inject({
+      method: 'GET',
+      url: '/v1/desktops/desk-2',
+      headers: authHeaders
+    });
+    assert.equal(getDesktop.statusCode, 200);
+    assert.equal(getDesktop.json().routeAuth.mode, 'auth_request');
+
+    const doctor = await app.inject({
+      method: 'GET',
+      url: '/v1/desktops/desk-2/doctor',
+      headers: authHeaders
+    });
+    assert.equal(doctor.statusCode, 200);
+    assert.equal(doctor.json().checks.nginx.protected, true);
+    assert.equal(doctor.json().routeAuth.mode, 'auth_request');
+
+    const snippetPath = path.join(tmpRoot, 'nginx', 'desk-2.conf');
+    const snippet = await fs.readFile(snippetPath, 'utf-8');
+    assert.match(snippet, /auth_request \/_aadm\/auth\/desk-2;/);
+    assert.match(snippet, /proxy_pass http:\/\/127\.0\.0\.1:3001\/verify;/);
   }
 );
 
@@ -163,11 +222,24 @@ test(
     calls = [];
     failNginxTest = true;
 
+    const before = await app.inject({
+      method: 'GET',
+      url: '/v1/desktops',
+      headers: authHeaders
+    });
+    assert.equal(before.statusCode, 200);
+    const beforeDesktops = before.json().desktops;
+    const failedDisplay = beforeDesktops.length + 1;
+
     const create = await app.inject({
       method: 'POST',
       url: '/v1/desktops',
       headers: { ...authHeaders, 'content-type': 'application/json' },
-      payload: { owner: 'codex', label: 'rollback' }
+      payload: {
+        owner: 'codex',
+        label: 'rollback',
+        routeAuthMode: 'auth_request'
+      }
     });
     assert.equal(create.statusCode, 500);
 
@@ -179,11 +251,11 @@ test(
     assert.equal(list.statusCode, 200);
     assert.equal(
       list.json().desktops.length,
-      1,
-      'only initial successful desktop should remain'
+      beforeDesktops.length,
+      'failed create should not add a desktop record'
     );
 
-    const snippetPath = path.join(tmpRoot, 'nginx', 'desk-2.conf');
+    const snippetPath = path.join(tmpRoot, 'nginx', `desk-${failedDisplay}.conf`);
     await assert.rejects(fs.access(snippetPath));
 
     const stopCalls = calls.filter(
@@ -202,6 +274,15 @@ test(
     failNginxTest = false;
     saveFailuresRemaining = 1;
 
+    const before = await app.inject({
+      method: 'GET',
+      url: '/v1/desktops',
+      headers: authHeaders
+    });
+    assert.equal(before.statusCode, 200);
+    const beforeDesktops = before.json().desktops;
+    const failedDisplay = beforeDesktops.length + 1;
+
     const create = await app.inject({
       method: 'POST',
       url: '/v1/desktops',
@@ -219,11 +300,11 @@ test(
     assert.equal(list.statusCode, 200);
     assert.equal(
       list.json().desktops.length,
-      1,
+      beforeDesktops.length,
       'state save failure should not add a partial desktop record'
     );
 
-    const snippetPath = path.join(tmpRoot, 'nginx', 'desk-2.conf');
+    const snippetPath = path.join(tmpRoot, 'nginx', `desk-${failedDisplay}.conf`);
     await assert.rejects(fs.access(snippetPath));
 
     const stopCalls = calls.filter(
@@ -241,6 +322,14 @@ test(
     calls = [];
     saveFailuresRemaining = 1;
 
+    const before = await app.inject({
+      method: 'GET',
+      url: '/v1/desktops',
+      headers: authHeaders
+    });
+    assert.equal(before.statusCode, 200);
+    const beforeDesktops = before.json().desktops;
+
     const destroy = await app.inject({
       method: 'DELETE',
       url: '/v1/desktops/desk-1',
@@ -257,7 +346,7 @@ test(
     assert.equal(list.statusCode, 200);
     assert.equal(
       list.json().desktops.length,
-      1,
+      beforeDesktops.length,
       'destroy save failure should preserve the persisted desktop record'
     );
 

--- a/test/integration/server.test.ts
+++ b/test/integration/server.test.ts
@@ -25,8 +25,7 @@ async function importServerWithEnv() {
   const netMod = await import('../../src/util/net.ts');
   configMod.config.authToken = 'test-token';
   configMod.config.desktopRouteAuthMode = 'none';
-  configMod.config.desktopRouteAuthRequestUrl =
-    'http://127.0.0.1:3001/verify';
+  configMod.config.desktopRouteAuthRequestUrl = 'http://127.0.0.1:3001/verify';
   configMod.config.desktopRouteAuthRequestHeaders = [
     'x-auth-request-user',
     'x-orchestrator-token'
@@ -255,7 +254,11 @@ test(
       'failed create should not add a desktop record'
     );
 
-    const snippetPath = path.join(tmpRoot, 'nginx', `desk-${failedDisplay}.conf`);
+    const snippetPath = path.join(
+      tmpRoot,
+      'nginx',
+      `desk-${failedDisplay}.conf`
+    );
     await assert.rejects(fs.access(snippetPath));
 
     const stopCalls = calls.filter(
@@ -304,7 +307,11 @@ test(
       'state save failure should not add a partial desktop record'
     );
 
-    const snippetPath = path.join(tmpRoot, 'nginx', `desk-${failedDisplay}.conf`);
+    const snippetPath = path.join(
+      tmpRoot,
+      'nginx',
+      `desk-${failedDisplay}.conf`
+    );
     await assert.rejects(fs.access(snippetPath));
 
     const stopCalls = calls.filter(

--- a/test/unit/nginx.test.ts
+++ b/test/unit/nginx.test.ts
@@ -4,7 +4,7 @@ import assert from 'node:assert/strict';
 import { buildSnippet } from '../../src/util/nginx.ts';
 
 test('buildSnippet generates redirect and websocket-safe location blocks', () => {
-  const snippet = buildSnippet(3, 6083);
+  const snippet = buildSnippet('desk-3', 3, 6083);
   assert.match(snippet, /location = \/desktop\/3\//);
   assert.match(
     snippet,
@@ -16,4 +16,23 @@ test('buildSnippet generates redirect and websocket-safe location blocks', () =>
   assert.match(snippet, /proxy_set_header Connection "upgrade";/);
   assert.match(snippet, /proxy_read_timeout 7d;/);
   assert.match(snippet, /proxy_send_timeout 7d;/);
+  assert.doesNotMatch(snippet, /auth_request/);
+});
+
+test('buildSnippet can protect a route with auth_request', () => {
+  const snippet = buildSnippet('desk-3', 3, 6083, {
+    mode: 'auth_request',
+    authRequest: {
+      url: 'http://127.0.0.1:3001/verify',
+      forwardedHeaders: ['x-auth-request-user', 'x-orchestrator-token']
+    }
+  });
+
+  assert.match(snippet, /location = \/_aadm\/auth\/desk-3/);
+  assert.match(snippet, /internal;/);
+  assert.match(snippet, /proxy_pass http:\/\/127\.0\.0\.1:3001\/verify;/);
+  assert.match(snippet, /proxy_set_header X-Original-URI \$request_uri;/);
+  assert.match(snippet, /proxy_set_header x-auth-request-user \$http_x_auth_request_user;/);
+  assert.match(snippet, /proxy_set_header x-orchestrator-token \$http_x_orchestrator_token;/);
+  assert.match(snippet, /auth_request \/_aadm\/auth\/desk-3;/);
 });

--- a/test/unit/nginx.test.ts
+++ b/test/unit/nginx.test.ts
@@ -35,4 +35,8 @@ test('buildSnippet can protect a route with auth_request', () => {
   assert.match(snippet, /proxy_set_header x-auth-request-user \$http_x_auth_request_user;/);
   assert.match(snippet, /proxy_set_header x-orchestrator-token \$http_x_orchestrator_token;/);
   assert.match(snippet, /auth_request \/_aadm\/auth\/desk-3;/);
+  assert.match(
+    snippet,
+    /location = \/desktop\/3\/ \{\n  auth_request \/_aadm\/auth\/desk-3;\n  proxy_pass http:\/\/127\.0\.0\.1:6083\/vnc\.html\?path=desktop\/3\/websockify&resize=remote&autoconnect=1;/
+  );
 });

--- a/test/unit/nginx.test.ts
+++ b/test/unit/nginx.test.ts
@@ -32,11 +32,17 @@ test('buildSnippet can protect a route with auth_request', () => {
   assert.match(snippet, /internal;/);
   assert.match(snippet, /proxy_pass http:\/\/127\.0\.0\.1:3001\/verify;/);
   assert.match(snippet, /proxy_set_header X-Original-URI \$request_uri;/);
-  assert.match(snippet, /proxy_set_header x-auth-request-user \$http_x_auth_request_user;/);
-  assert.match(snippet, /proxy_set_header x-orchestrator-token \$http_x_orchestrator_token;/);
+  assert.match(
+    snippet,
+    /proxy_set_header x-auth-request-user \$http_x_auth_request_user;/
+  );
+  assert.match(
+    snippet,
+    /proxy_set_header x-orchestrator-token \$http_x_orchestrator_token;/
+  );
   assert.match(snippet, /auth_request \/_aadm\/auth\/desk-3;/);
   assert.match(
     snippet,
-    /location = \/desktop\/3\/ \{\n  auth_request \/_aadm\/auth\/desk-3;\n  proxy_pass http:\/\/127\.0\.0\.1:6083\/vnc\.html\?path=desktop\/3\/websockify&resize=remote&autoconnect=1;/
+    /location = \/desktop\/3\/ \{\n {2}auth_request \/_aadm\/auth\/desk-3;\n {2}proxy_pass http:\/\/127\.0\.0\.1:6083\/vnc\.html\?path=desktop\/3\/websockify&resize=remote&autoconnect=1;/
   );
 });

--- a/test/unit/route-auth.test.ts
+++ b/test/unit/route-auth.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  normalizeAuthRequestUrl,
+  normalizeDesktopRouteAuth,
+  parseForwardedHeaderNames
+} from '../../src/util/route-auth.ts';
+
+test('parseForwardedHeaderNames keeps only safe header tokens', () => {
+  assert.deepEqual(
+    parseForwardedHeaderNames('X-Test, bad header, X-Test, x-ok'),
+    ['x-test', 'x-ok']
+  );
+});
+
+test('normalizeAuthRequestUrl accepts only safe http(s) urls', () => {
+  assert.equal(
+    normalizeAuthRequestUrl('http://127.0.0.1:3001/verify'),
+    'http://127.0.0.1:3001/verify'
+  );
+  assert.equal(normalizeAuthRequestUrl('ftp://127.0.0.1/verify'), undefined);
+  assert.equal(
+    normalizeAuthRequestUrl('http://127.0.0.1/verify;drop'),
+    undefined
+  );
+});
+
+test('normalizeDesktopRouteAuth rejects unsafe persisted auth config', () => {
+  assert.equal(
+    normalizeDesktopRouteAuth({
+      mode: 'auth_request',
+      authRequest: {
+        url: 'http://127.0.0.1/verify\nmalicious',
+        forwardedHeaders: ['x-smoke-auth']
+      }
+    }),
+    undefined
+  );
+
+  assert.deepEqual(
+    normalizeDesktopRouteAuth({
+      mode: 'auth_request',
+      authRequest: {
+        url: 'http://127.0.0.1:3001/verify',
+        forwardedHeaders: ['X-Smoke-Auth', 'bad header']
+      }
+    }),
+    {
+      mode: 'auth_request',
+      authRequest: {
+        url: 'http://127.0.0.1:3001/verify',
+        forwardedHeaders: ['x-smoke-auth']
+      }
+    }
+  );
+});


### PR DESCRIPTION
## Summary
- add deployment and per-desktop route auth configuration for noVNC routes
- generate nginx `auth_request` snippets and surface effective auth mode in create/doctor responses
- document verifier configuration and add regression coverage for protected route flows

## Testing
- `npm test`
- `npm run build`