### PR TITLE
Add lifecycle hardening and MCP adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,9 @@ AADM_PORT=8899
 
 # Optional auth. If set, requests must send: Authorization: Bearer <token>
 AADM_AUTH_TOKEN=
+#
+# Optional TTL sweeper. Only desktops created with ttlMinutes are eligible.
+AADM_TTL_SWEEP_INTERVAL_MS=60000
 
 # Optional route protection for externally exposed desktop routes.
 # `none` keeps current behavior. `auth_request` requires a verifier URL.
@@ -28,6 +31,10 @@ AADM_TLS_STAGING=false
 # Public base URL used to generate noVNC links (what YOU open in your browser)
 # Example: https://mybox.example.com
 AADM_PUBLIC_BASE_URL=https://host.example.com
+#
+# Optional comma-separated allowlist for create.startUrl hostnames.
+# Example: github.com,example.com
+AADM_ALLOWED_START_URL_DOMAINS=
 
 # Nginx snippets
 AADM_NGINX_SNIPPET_DIR=/etc/nginx/conf.d/agent-desktops

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Default:
 - route template: `/desktop/{display}/`
 - state dir: `./data`
 - route auth mode: `none`
+- TTL sweeper: every 60 seconds, but it only deletes desktops created with `ttlMinutes`
 
 ### Protected desktop routes
 
@@ -345,6 +346,8 @@ curl -sX POST http://127.0.0.1:8899/v1/desktops \
   -d '{ "owner":"codex", "label":"issue-123", "ttlMinutes":120, "startUrl":"https://example.com" }' | jq
 ```
 
+`ttlMinutes` is optional. If omitted, the desktop does not expire automatically.
+
 To opt a desktop into route protection explicitly:
 
 ```bash
@@ -358,6 +361,9 @@ curl -sX POST http://127.0.0.1:8899/v1/desktops \
 - `inherit` to use the deployment default
 - `none` to force an open route
 - `auth_request` to require the configured verifier
+- `token` to return a manager-issued access URL
+
+If `AADM_ALLOWED_START_URL_DOMAINS` is set, `startUrl` must match one of the allowed hostnames or subdomains.
 
 ### List
 
@@ -421,6 +427,18 @@ npm run cli -- access-url --id desk-3
 npm run cli -- list
 npm run cli -- destroy --id desk-3
 ```
+
+---
+
+## MCP server
+
+This repo also includes a stdio MCP adapter that exposes the desktop lifecycle as tools for agent clients:
+
+```bash
+AADM_URL=http://127.0.0.1:8899 npm run mcp
+```
+
+See [docs/mcp.md](./docs/mcp.md) for the tool list and Codex/Claude wiring notes.
 
 ---
 
@@ -492,6 +510,7 @@ See `.env.example` for:
 - auth token
 - desktop route auth mode and verifier settings
 - token route auth secret and TTL
+- TTL sweep interval and `startUrl` allowlist
 - HTTPS/certbot smoke deployment variables
 - base URL template for noVNC links
 - state directory

--- a/TODO.md
+++ b/TODO.md
@@ -2,9 +2,9 @@
 
 ## MVP hardening
 
-- [ ] Add TTL sweeper that deletes expired desktops every minute
+- [x] Add TTL sweeper that deletes expired desktops every minute
 - [ ] Add per-desktop “idle” tracking using ai-agent-browser heartbeat (optional)
-- [ ] Add structured logging with request ids
+- [x] Add structured logging with request ids
 
 ## Nginx routing
 
@@ -15,17 +15,17 @@
 ## Orchestration
 
 - [ ] Add “restart desktop” endpoint that restarts all units in order
-- [ ] Add port collision detection via `ss -lnt`
+- [x] Add port collision detection via `ss -lnt`
 
 ## Agent skill integration
 
-- [ ] Add MCP server wrapper exposing tools:
+- [x] Add MCP server wrapper exposing tools:
   - desktop.create
   - desktop.list
   - desktop.get
   - desktop.destroy
   - desktop.doctor
-- [ ] Add tool docs for Claude/Codex configuration
+- [x] Add tool docs for Claude/Codex configuration
 
 ## Testing
 
@@ -42,9 +42,9 @@
 
 ## Security
 
-- [ ] Optional bearer auth for manager API (env-controlled)
-- [ ] Redaction of secrets in logs (URLs, tokens)
-- [ ] Add “allowed startUrl domains” allowlist option
+- [x] Optional bearer auth for manager API (env-controlled)
+- [x] Redaction of secrets in logs (URLs, tokens)
+- [x] Add “allowed startUrl domains” allowlist option
 
 ## Web auth
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,6 @@
+# Documentation
+
+- [EC2 smoke test guide](./ec2-smoke-test.md)
+- [MCP usage and client wiring](./mcp.md)
+- [First-party dependency graph](./first-party-dependency-graph.md)
+- [Workspace code catalog](./workspace-code-catalog.md)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,46 @@
+# MCP Integration
+
+`ai-agent-desktop-manager` ships a stdio MCP server wrapper around the localhost manager API.
+
+## Exposed tools
+
+- `desktop.create`
+- `desktop.list`
+- `desktop.get`
+- `desktop.destroy`
+- `desktop.doctor`
+
+All tools call the manager API at `AADM_URL` and forward `AADM_AUTH_TOKEN` as a bearer token when it is set.
+
+## Run locally
+
+```bash
+AADM_URL=http://127.0.0.1:8899 npm run mcp
+```
+
+If the manager API is protected:
+
+```bash
+AADM_URL=http://127.0.0.1:8899 \
+AADM_AUTH_TOKEN=replace-me \
+npm run mcp
+```
+
+## Codex and Claude
+
+Register a stdio MCP server with:
+
+- command: `npm`
+- args: `run`, `mcp`
+- working directory: this repository root
+- env:
+  - `AADM_URL=http://127.0.0.1:8899`
+  - `AADM_AUTH_TOKEN=...` when API auth is enabled
+
+The exact config file shape varies by client version, but the process contract is stable: launch `npm run mcp` from this repo and provide the manager URL and optional bearer token through the environment.
+
+## Notes
+
+- `ttlMinutes` remains optional. Only desktops created with a TTL are eligible for background cleanup.
+- `startUrl` can be restricted with `AADM_ALLOWED_START_URL_DOMAINS`.
+- The manager rejects create requests if the allocated desktop ports are already listening according to `ss -lntH`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^16.4.5",
         "fastify": "^4.28.1",
         "proper-lockfile": "^4.1.2",
@@ -636,6 +637,18 @@
         "fast-deep-equal": "^3.1.3"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -686,6 +699,63 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/@pinojs/redact": {
@@ -974,6 +1044,19 @@
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
       "license": "MIT"
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1075,6 +1158,30 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -1088,6 +1195,66 @@
         "node": "18 || 20 || >=22"
       }
     },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cookie": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
@@ -1097,11 +1264,36 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1116,7 +1308,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1137,6 +1328,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -1147,6 +1347,65 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -1190,6 +1449,12 @@
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1427,6 +1692,97 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-content-type-parse": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-1.1.0.tgz",
@@ -1587,6 +1943,27 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/find-my-way": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-8.2.2.tgz",
@@ -1648,6 +2025,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1661,6 +2047,52 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -1702,11 +2134,92 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -1726,6 +2239,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/ipaddr.js": {
@@ -1760,12 +2288,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/json-buffer": {
       "version": "3.0.1",
@@ -1788,6 +2330,12 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -1847,6 +2395,61 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
@@ -1867,7 +2470,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -1877,6 +2479,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -1884,6 +2516,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/optionator": {
@@ -1936,6 +2589,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -1950,10 +2612,19 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/picomatch": {
@@ -2021,6 +2692,15 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/playwright": {
       "version": "1.59.1",
@@ -2148,11 +2828,50 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/real-require": {
       "version": "0.2.0",
@@ -2216,6 +2935,22 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "license": "MIT"
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safe-regex2": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-3.1.0.tgz",
@@ -2233,6 +2968,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/secure-json-parse": {
       "version": "2.7.0",
@@ -2252,17 +2993,67 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2275,10 +3066,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -2303,6 +3165,15 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/synckit": {
@@ -2356,6 +3227,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -2400,6 +3280,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typescript": {
@@ -2447,6 +3341,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -2457,11 +3360,19 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -2483,6 +3394,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -2503,6 +3420,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "package:release": "bash ./scripts/package-release.sh",
     "start": "node dist/index.js",
     "cli": "tsx src/cli/aadm.ts",
+    "mcp": "tsx src/cli/aadm-mcp.ts",
     "aab-console": "tsx src/cli/aab-console.ts",
     "lint:smoke": "node --check smoke/browser-smoke.mjs",
     "smoke:playwright": "bash ./scripts/smoke-playwright.sh",
@@ -25,6 +26,7 @@
     "prettier:fix": "prettier . --write"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^16.4.5",
     "fastify": "^4.28.1",
     "proper-lockfile": "^4.1.2",

--- a/src/cli/aadm-mcp.ts
+++ b/src/cli/aadm-mcp.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { appVersion } from '../util/app-version.js';
+import { desktopToolDefinitions, invokeDesktopTool } from '../mcp/tools.js';
+
+const server = new McpServer({
+  name: 'ai-agent-desktop-manager',
+  version: appVersion
+});
+
+for (const tool of desktopToolDefinitions) {
+  server.registerTool(
+    tool.name,
+    {
+      description: tool.description,
+      inputSchema: tool.inputSchema
+    },
+    async (args: Record<string, unknown>) =>
+      await invokeDesktopTool(tool.name, args)
+  );
+}
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((error) => {
+  console.error(String((error as Error)?.stack ?? error));
+  process.exit(1);
+});

--- a/src/cli/aadm.ts
+++ b/src/cli/aadm.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { argv, exit } from 'node:process';
+import { requestJson, AadmRequestError } from '../util/aadm-client.js';
 
 type Cmd = 'create' | 'list' | 'get' | 'destroy' | 'doctor' | 'access-url';
 
@@ -9,37 +10,11 @@ function arg(name: string) {
   return argv[idx + 1];
 }
 
-function baseUrl() {
-  return process.env.AADM_URL ?? 'http://127.0.0.1:8899';
-}
-
-async function req(path: string, init?: RequestInit) {
-  const url = `${baseUrl()}${path}`;
-  const headers = { ...((init?.headers as Record<string, string>) || {}) };
-  const token = process.env.AADM_AUTH_TOKEN;
-  if (token) headers['Authorization'] = `Bearer ${token}`;
-  const res = await fetch(url, { ...init, headers });
-  const text = await res.text();
-  let data: unknown;
-  try {
-    data = JSON.parse(text);
-  } catch {
-    data = text;
-  }
-  if (!res.ok) {
-    console.error(
-      JSON.stringify({ ok: false, status: res.status, data }, null, 2)
-    );
-    exit(1);
-  }
-  return data;
-}
-
 async function main() {
   const cmd = (argv[2] as Cmd) || 'list';
 
   if (cmd === 'list') {
-    console.log(JSON.stringify(await req('/v1/desktops'), null, 2));
+    console.log(JSON.stringify(await requestJson('/v1/desktops'), null, 2));
     return;
   }
 
@@ -58,10 +33,9 @@ async function main() {
 
     console.log(
       JSON.stringify(
-        await req('/v1/desktops', {
+        await requestJson('/v1/desktops', {
           method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify(body)
+          body
         }),
         null,
         2
@@ -80,10 +54,9 @@ async function main() {
 
     console.log(
       JSON.stringify(
-        await req(`/v1/desktops/${id}/access-url`, {
+        await requestJson(`/v1/desktops/${id}/access-url`, {
           method: 'POST',
-          headers: { 'content-type': 'application/json' },
-          body: JSON.stringify(body)
+          body
         }),
         null,
         2
@@ -95,7 +68,9 @@ async function main() {
   if (cmd === 'get') {
     const id = arg('--id');
     if (!id) throw new Error('missing --id');
-    console.log(JSON.stringify(await req(`/v1/desktops/${id}`), null, 2));
+    console.log(
+      JSON.stringify(await requestJson(`/v1/desktops/${id}`), null, 2)
+    );
     return;
   }
 
@@ -103,7 +78,7 @@ async function main() {
     const id = arg('--id');
     if (!id) throw new Error('missing --id');
     console.log(
-      JSON.stringify(await req(`/v1/desktops/${id}/doctor`), null, 2)
+      JSON.stringify(await requestJson(`/v1/desktops/${id}/doctor`), null, 2)
     );
     return;
   }
@@ -113,7 +88,7 @@ async function main() {
     if (!id) throw new Error('missing --id');
     console.log(
       JSON.stringify(
-        await req(`/v1/desktops/${id}`, { method: 'DELETE' }),
+        await requestJson(`/v1/desktops/${id}`, { method: 'DELETE' }),
         null,
         2
       )
@@ -128,6 +103,12 @@ async function main() {
 }
 
 main().catch((e) => {
+  if (e instanceof AadmRequestError) {
+    console.error(
+      JSON.stringify({ ok: false, status: e.status, data: e.data }, null, 2)
+    );
+    exit(1);
+  }
   console.error(String(e?.message ?? e));
   exit(1);
 });

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,0 +1,146 @@
+import { z } from 'zod/v4';
+import {
+  AadmRequestError,
+  requestJson,
+  type RequestJsonOptions
+} from '../util/aadm-client.js';
+
+type McpToolResult = {
+  content: Array<{ type: 'text'; text: string }>;
+  structuredContent?: Record<string, unknown>;
+  isError?: boolean;
+};
+
+type InvokeDeps = Pick<RequestJsonOptions, 'fetchImpl' | 'baseUrl'>;
+
+const createDesktopSchema = {
+  owner: z.string().optional(),
+  label: z.string().optional(),
+  ttlMinutes: z.number().int().positive().optional(),
+  startUrl: z.string().url().optional(),
+  routeAuthMode: z.enum(['inherit', 'none', 'auth_request', 'token']).optional()
+};
+
+const idSchema = {
+  id: z.string().min(1)
+};
+
+export const desktopToolDefinitions = [
+  {
+    name: 'desktop.create',
+    description: 'Create a new managed desktop.',
+    inputSchema: createDesktopSchema
+  },
+  {
+    name: 'desktop.list',
+    description: 'List all managed desktops.',
+    inputSchema: {}
+  },
+  {
+    name: 'desktop.get',
+    description: 'Fetch one desktop by id.',
+    inputSchema: idSchema
+  },
+  {
+    name: 'desktop.destroy',
+    description: 'Destroy one desktop by id.',
+    inputSchema: idSchema
+  },
+  {
+    name: 'desktop.doctor',
+    description: 'Run doctor checks for one desktop.',
+    inputSchema: idSchema
+  }
+] as const;
+
+function successResult(data: unknown): McpToolResult {
+  const structuredContent =
+    data && typeof data === 'object' && !Array.isArray(data)
+      ? (data as Record<string, unknown>)
+      : { result: data };
+
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+    structuredContent
+  };
+}
+
+function errorResult(error: unknown): McpToolResult {
+  if (error instanceof AadmRequestError) {
+    return {
+      isError: true,
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              ok: false,
+              status: error.status,
+              data: error.data
+            },
+            null,
+            2
+          )
+        }
+      ],
+      structuredContent: { ok: false, status: error.status, data: error.data }
+    };
+  }
+
+  return {
+    isError: true,
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            ok: false,
+            error: String((error as Error)?.message ?? error)
+          },
+          null,
+          2
+        )
+      }
+    ]
+  };
+}
+
+export async function invokeDesktopTool(
+  name: (typeof desktopToolDefinitions)[number]['name'],
+  args: Record<string, unknown> = {},
+  deps: InvokeDeps = {}
+) {
+  try {
+    switch (name) {
+      case 'desktop.create':
+        return successResult(
+          await requestJson('/v1/desktops', {
+            method: 'POST',
+            body: args,
+            ...deps
+          })
+        );
+      case 'desktop.list':
+        return successResult(await requestJson('/v1/desktops', deps));
+      case 'desktop.get':
+        return successResult(
+          await requestJson(`/v1/desktops/${String(args.id)}`, deps)
+        );
+      case 'desktop.destroy':
+        return successResult(
+          await requestJson(`/v1/desktops/${String(args.id)}`, {
+            method: 'DELETE',
+            ...deps
+          })
+        );
+      case 'desktop.doctor':
+        return successResult(
+          await requestJson(`/v1/desktops/${String(args.id)}/doctor`, deps)
+        );
+      default:
+        throw new Error(`unknown_tool:${String(name)}`);
+    }
+  } catch (error) {
+    return errorResult(error);
+  }
+}

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import {
   AadmRequestError,
   requestJson,
@@ -13,17 +13,19 @@ type McpToolResult = {
 
 type InvokeDeps = Pick<RequestJsonOptions, 'fetchImpl' | 'baseUrl'>;
 
-const createDesktopSchema = {
+const createDesktopSchema = z.object({
   owner: z.string().optional(),
   label: z.string().optional(),
   ttlMinutes: z.number().int().positive().optional(),
   startUrl: z.string().url().optional(),
   routeAuthMode: z.enum(['inherit', 'none', 'auth_request', 'token']).optional()
-};
+});
 
-const idSchema = {
+const idSchema = z.object({
   id: z.string().min(1)
-};
+});
+
+const listSchema = z.object({});
 
 export const desktopToolDefinitions = [
   {
@@ -34,7 +36,7 @@ export const desktopToolDefinitions = [
   {
     name: 'desktop.list',
     description: 'List all managed desktops.',
-    inputSchema: {}
+    inputSchema: listSchema
   },
   {
     name: 'desktop.get',
@@ -105,6 +107,16 @@ function errorResult(error: unknown): McpToolResult {
   };
 }
 
+function validatedArgs<T extends z.ZodTypeAny>(schema: T, args: unknown) {
+  const parsed = schema.safeParse(args);
+  if (!parsed.success) {
+    throw new Error(
+      `invalid_arguments:${parsed.error.issues.map((issue) => issue.message).join(', ')}`
+    );
+  }
+  return parsed.data;
+}
+
 export async function invokeDesktopTool(
   name: (typeof desktopToolDefinitions)[number]['name'],
   args: Record<string, unknown> = {},
@@ -112,31 +124,38 @@ export async function invokeDesktopTool(
 ) {
   try {
     switch (name) {
-      case 'desktop.create':
+      case 'desktop.create': {
+        const body = validatedArgs(createDesktopSchema, args);
         return successResult(
           await requestJson('/v1/desktops', {
             method: 'POST',
-            body: args,
+            body,
             ...deps
           })
         );
+      }
       case 'desktop.list':
+        validatedArgs(listSchema, args);
         return successResult(await requestJson('/v1/desktops', deps));
-      case 'desktop.get':
+      case 'desktop.get': {
+        const { id } = validatedArgs(idSchema, args);
+        return successResult(await requestJson(`/v1/desktops/${id}`, deps));
+      }
+      case 'desktop.destroy': {
+        const { id } = validatedArgs(idSchema, args);
         return successResult(
-          await requestJson(`/v1/desktops/${String(args.id)}`, deps)
-        );
-      case 'desktop.destroy':
-        return successResult(
-          await requestJson(`/v1/desktops/${String(args.id)}`, {
+          await requestJson(`/v1/desktops/${id}`, {
             method: 'DELETE',
             ...deps
           })
         );
-      case 'desktop.doctor':
+      }
+      case 'desktop.doctor': {
+        const { id } = validatedArgs(idSchema, args);
         return successResult(
-          await requestJson(`/v1/desktops/${String(args.id)}/doctor`, deps)
+          await requestJson(`/v1/desktops/${id}/doctor`, deps)
         );
+      }
       default:
         throw new Error(`unknown_tool:${String(name)}`);
     }

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,7 @@ import lockfile from 'proper-lockfile';
 import path from 'node:path';
 import fs from 'node:fs/promises';
 import { constants as fsConstants } from 'node:fs';
+import crypto from 'node:crypto';
 
 import { config } from './util/config.js';
 import { authHook } from './util/auth.js';
@@ -33,7 +34,11 @@ import {
 import { CreateAccessUrlBody, CreateDesktopBody } from './api/types.js';
 import { isPortOpen } from './util/net.js';
 import { appVersion } from './util/app-version.js';
-import { buildLoggerOptions, attachRequestIdHeader } from './util/logging.js';
+import {
+  buildLoggerOptions,
+  attachRequestIdHeader,
+  REQUEST_ID_HEADER
+} from './util/logging.js';
 import {
   createDesktopAccessToken,
   desktopAccessCookieName,
@@ -328,6 +333,14 @@ type BuildAppOptions = {
   loggerStream?: NodeJS.WritableStream;
 };
 
+function genReqId(req: { headers: Record<string, unknown> }) {
+  const incoming = req.headers[REQUEST_ID_HEADER];
+  if (typeof incoming === 'string' && incoming.trim()) {
+    return incoming.trim();
+  }
+  return crypto.randomUUID();
+}
+
 function authHeadersForInternalRequest() {
   if (!config.authToken) return undefined;
   return { authorization: `Bearer ${config.authToken}` };
@@ -382,6 +395,7 @@ export async function sweepExpiredDesktops(
 export function buildApp(options: BuildAppOptions = {}) {
   const app = Fastify({
     logger: buildLoggerOptions(options.loggerStream) as never,
+    genReqId,
     requestIdHeader: 'x-request-id',
     disableRequestLogging: false
   }) as unknown as FastifyInstance;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,5 @@
 import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
 import lockfile from 'proper-lockfile';
 import path from 'node:path';
 import fs from 'node:fs/promises';
@@ -32,6 +33,7 @@ import {
 import { CreateAccessUrlBody, CreateDesktopBody } from './api/types.js';
 import { isPortOpen } from './util/net.js';
 import { appVersion } from './util/app-version.js';
+import { buildLoggerOptions, attachRequestIdHeader } from './util/logging.js';
 import {
   createDesktopAccessToken,
   desktopAccessCookieName,
@@ -39,6 +41,8 @@ import {
   resolveDesktopRouteAuth,
   verifyDesktopAccessToken
 } from './util/route-auth.js';
+import { findPortCollisions } from './util/port-usage.js';
+import { isStartUrlAllowed } from './util/start-url.js';
 
 function desktopId(display: number) {
   return `desk-${display}`;
@@ -320,9 +324,71 @@ async function restoreDestroyedDesktop(
   return issues;
 }
 
-export function buildApp() {
-  const app = Fastify({ logger: true });
+type BuildAppOptions = {
+  loggerStream?: NodeJS.WritableStream;
+};
+
+function authHeadersForInternalRequest() {
+  if (!config.authToken) return undefined;
+  return { authorization: `Bearer ${config.authToken}` };
+}
+
+export async function sweepExpiredDesktops(
+  app: Pick<FastifyInstance, 'inject' | 'log'>,
+  now = nowMs()
+) {
+  const state = await loadState();
+  const expiredDesktopIds = state.desktops
+    .filter(
+      (desktop) => desktop.expiresAt !== undefined && desktop.expiresAt <= now
+    )
+    .map((desktop) => desktop.id);
+
+  const deleted: string[] = [];
+  const failed: Array<{ id: string; statusCode: number; body: unknown }> = [];
+
+  for (const id of expiredDesktopIds) {
+    const response = await app.inject({
+      method: 'DELETE',
+      url: `/v1/desktops/${id}`,
+      headers: authHeadersForInternalRequest()
+    });
+
+    if (response.statusCode >= 200 && response.statusCode < 300) {
+      deleted.push(id);
+      continue;
+    }
+
+    let body: unknown = response.body;
+    try {
+      body = response.json();
+    } catch {
+      // keep raw body
+    }
+
+    failed.push({ id, statusCode: response.statusCode, body });
+  }
+
+  if (deleted.length > 0) {
+    app.log.info({ deleted }, 'deleted expired desktops');
+  }
+  if (failed.length > 0) {
+    app.log.warn({ failed }, 'failed to delete some expired desktops');
+  }
+
+  return { deleted, failed };
+}
+
+export function buildApp(options: BuildAppOptions = {}) {
+  const app = Fastify({
+    logger: buildLoggerOptions(options.loggerStream) as never,
+    requestIdHeader: 'x-request-id',
+    disableRequestLogging: false
+  }) as unknown as FastifyInstance;
   app.addHook('preHandler', authHook);
+  app.addHook('onRequest', async (req, reply) => {
+    attachRequestIdHeader(reply, req.log, req.id);
+  });
 
   app.get('/health', async () => {
     return {
@@ -467,9 +533,33 @@ export function buildApp() {
         details: parsed.error.flatten()
       });
 
+    if (
+      parsed.data.startUrl &&
+      !isStartUrlAllowed(parsed.data.startUrl, config.allowedStartUrlDomains)
+    ) {
+      return reply.code(400).send({
+        ok: false,
+        error: 'start_url_not_allowed',
+        allowedDomains: config.allowedStartUrlDomains
+      });
+    }
+
     return await withStateLock(async () => {
       const st = await loadState();
       const alloc = allocate(st.desktops);
+      const portCollisions = await findPortCollisions([
+        alloc.vncPort,
+        alloc.wsPort,
+        alloc.cdpPort,
+        alloc.aabPort
+      ]);
+      if (portCollisions.length > 0) {
+        return reply.code(409).send({
+          ok: false,
+          error: 'ports_unavailable',
+          ports: portCollisions
+        });
+      }
 
       const id = desktopId(alloc.display);
       const createdAt = nowMs();
@@ -773,6 +863,15 @@ export async function startServer() {
   await fs.access(config.systemctlBin, fsConstants.X_OK);
 
   const app = buildApp();
+  if (config.ttlSweepIntervalMs > 0) {
+    const timer = setInterval(() => {
+      void sweepExpiredDesktops(app);
+    }, config.ttlSweepIntervalMs);
+    timer.unref();
+    app.addHook('onClose', async () => {
+      clearInterval(timer);
+    });
+  }
   await app.listen({ host: config.host, port: config.port });
   app.log.info(
     { host: config.host, port: config.port },

--- a/src/util/aadm-client.ts
+++ b/src/util/aadm-client.ts
@@ -1,0 +1,67 @@
+type FetchLike = typeof fetch;
+
+export type RequestJsonOptions = {
+  method?: string;
+  headers?: Record<string, string>;
+  body?: unknown;
+  fetchImpl?: FetchLike;
+  baseUrl?: string;
+};
+
+export class AadmRequestError extends Error {
+  status: number;
+  data: unknown;
+
+  constructor(status: number, data: unknown) {
+    super(`request_failed:${status}`);
+    this.status = status;
+    this.data = data;
+  }
+}
+
+export function managerBaseUrl() {
+  return process.env.AADM_URL ?? 'http://127.0.0.1:8899';
+}
+
+export async function requestJson<T>(
+  path: string,
+  options: RequestJsonOptions = {}
+): Promise<T> {
+  const {
+    method,
+    headers = {},
+    body,
+    fetchImpl = fetch,
+    baseUrl = managerBaseUrl()
+  } = options;
+
+  const requestHeaders = { ...headers };
+  const token = process.env.AADM_AUTH_TOKEN;
+  if (token) {
+    requestHeaders.Authorization = `Bearer ${token}`;
+  }
+
+  if (body !== undefined) {
+    requestHeaders['content-type'] = 'application/json';
+  }
+
+  const response = await fetchImpl(`${baseUrl}${path}`, {
+    method,
+    headers: requestHeaders,
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {})
+  });
+
+  const text = await response.text();
+  let data: unknown = text;
+  try {
+    data = JSON.parse(text);
+  } catch {
+    // leave text response as-is
+  }
+
+  if (!response.ok) {
+    throw new AadmRequestError(response.status, data);
+  }
+
+  return data as T;
+}

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -161,10 +161,6 @@ function validateConfig() {
   ) {
     throw new Error('invalid_config:desktop_route_token_ttl_seconds');
   }
-
-  if (config.ttlSweepIntervalMs < 0) {
-    throw new Error('invalid_config:ttl_sweep_interval_ms');
-  }
 }
 
 validateConfig();

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -6,6 +6,7 @@ import {
   normalizeDesktopRouteTokenTtlSeconds,
   parseForwardedHeaderNames
 } from './route-auth.js';
+import { parseStartUrlDomainAllowlist } from './start-url.js';
 
 dotenv.config();
 
@@ -22,6 +23,7 @@ export const Config = z.object({
   port: z.number().int().default(8899),
 
   authToken: z.string().optional(),
+  ttlSweepIntervalMs: z.number().int().nonnegative().default(60_000),
   desktopRouteAuthMode: RouteAuthModeSchema.default('none'),
   desktopRouteAuthRequestUrl: z.string().url().optional(),
   desktopRouteAuthRequestHeaders: z.array(z.string()).default([]),
@@ -29,6 +31,7 @@ export const Config = z.object({
   desktopRouteTokenTtlSeconds: z.number().int().default(900),
 
   publicBaseUrl: z.string().url().default('https://host.example.com'),
+  allowedStartUrlDomains: z.array(z.string()).default([]),
 
   nginxSnippetDir: z.string().default('/etc/nginx/conf.d/agent-desktops'),
   nginxBin: z.string().default('/usr/sbin/nginx'),
@@ -60,6 +63,7 @@ export const config = Config.parse({
   port: intFromEnv('AADM_PORT', 8899),
 
   authToken: process.env.AADM_AUTH_TOKEN || undefined,
+  ttlSweepIntervalMs: intFromEnv('AADM_TTL_SWEEP_INTERVAL_MS', 60_000),
   desktopRouteAuthMode: process.env.AADM_DESKTOP_ROUTE_AUTH_MODE ?? 'none',
   desktopRouteAuthRequestUrl:
     process.env.AADM_DESKTOP_ROUTE_AUTH_REQUEST_URL || undefined,
@@ -74,6 +78,9 @@ export const config = Config.parse({
   ),
 
   publicBaseUrl: process.env.AADM_PUBLIC_BASE_URL ?? 'https://host.example.com',
+  allowedStartUrlDomains: parseStartUrlDomainAllowlist(
+    process.env.AADM_ALLOWED_START_URL_DOMAINS
+  ),
 
   nginxSnippetDir:
     process.env.AADM_NGINX_SNIPPET_DIR ?? '/etc/nginx/conf.d/agent-desktops',
@@ -153,6 +160,10 @@ function validateConfig() {
     undefined
   ) {
     throw new Error('invalid_config:desktop_route_token_ttl_seconds');
+  }
+
+  if (config.ttlSweepIntervalMs < 0) {
+    throw new Error('invalid_config:ttl_sweep_interval_ms');
   }
 }
 

--- a/src/util/exec.ts
+++ b/src/util/exec.ts
@@ -42,7 +42,7 @@ let runner: ExecRunner = defaultExecRunner;
 export async function execCmd(
   cmd: string,
   args: string[],
-  opts?: { sudo?: boolean }
+  opts?: { sudo?: boolean; env?: Record<string, string> }
 ): Promise<ExecResult> {
   return runner(cmd, args, opts);
 }

--- a/src/util/logging.ts
+++ b/src/util/logging.ts
@@ -1,0 +1,105 @@
+import crypto from 'node:crypto';
+import type { FastifyBaseLogger } from 'fastify';
+
+const REDACTED = '[REDACTED]';
+const REQUEST_ID_HEADER = 'x-request-id';
+
+function redactSensitiveQueryParams(url: string) {
+  try {
+    const parsed = new URL(url, 'http://localhost');
+    for (const key of ['token', 'access_token']) {
+      if (parsed.searchParams.has(key)) {
+        parsed.searchParams.set(key, REDACTED);
+      }
+    }
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return url.replace(/([?&](?:token|access_token)=)[^&]+/gi, `$1${REDACTED}`);
+  }
+}
+
+function sanitizeHeaders(
+  headers: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!headers) return undefined;
+
+  const sanitized = { ...headers };
+  for (const key of [
+    'authorization',
+    'cookie',
+    'set-cookie',
+    'x-orchestrator-token'
+  ]) {
+    if (key in sanitized) {
+      sanitized[key] = REDACTED;
+    }
+  }
+
+  return sanitized;
+}
+
+export function buildLoggerOptions(stream?: NodeJS.WritableStream) {
+  return {
+    level: 'info',
+    ...(stream ? { stream } : {}),
+    redact: {
+      paths: [
+        'req.headers.authorization',
+        'req.headers.cookie',
+        'req.headers["set-cookie"]',
+        'res.headers["set-cookie"]'
+      ],
+      censor: REDACTED
+    },
+    serializers: {
+      req(request: {
+        method?: string;
+        url?: string;
+        headers?: Record<string, unknown>;
+        id?: string;
+      }) {
+        return {
+          method: request.method,
+          url: redactSensitiveQueryParams(request.url ?? ''),
+          headers: sanitizeHeaders(request.headers),
+          reqId: request.id
+        };
+      },
+      res(reply: {
+        statusCode?: number;
+        getHeaders?: () => Record<string, unknown>;
+      }) {
+        return {
+          statusCode: reply.statusCode,
+          headers: sanitizeHeaders(
+            (reply.getHeaders?.() ?? {}) as Record<string, unknown>
+          )
+        };
+      },
+      err(error: Error & { code?: string }) {
+        return {
+          type: error.name,
+          message: error.message,
+          code: error.code,
+          stack: error.stack ?? ''
+        };
+      }
+    },
+    genReqId(req: { headers: Record<string, unknown> }) {
+      const incoming = req.headers[REQUEST_ID_HEADER];
+      if (typeof incoming === 'string' && incoming.trim()) {
+        return incoming.trim();
+      }
+      return crypto.randomUUID();
+    }
+  };
+}
+
+export function attachRequestIdHeader(
+  reply: { header: (name: string, value: string) => void },
+  logger: FastifyBaseLogger,
+  requestId: string
+) {
+  reply.header(REQUEST_ID_HEADER, requestId);
+  logger.debug({ reqId: requestId }, 'request received');
+}

--- a/src/util/logging.ts
+++ b/src/util/logging.ts
@@ -1,8 +1,7 @@
-import crypto from 'node:crypto';
 import type { FastifyBaseLogger } from 'fastify';
 
 const REDACTED = '[REDACTED]';
-const REQUEST_ID_HEADER = 'x-request-id';
+export const REQUEST_ID_HEADER = 'x-request-id';
 
 function redactSensitiveQueryParams(url: string) {
   try {
@@ -84,13 +83,6 @@ export function buildLoggerOptions(stream?: NodeJS.WritableStream) {
           stack: error.stack ?? ''
         };
       }
-    },
-    genReqId(req: { headers: Record<string, unknown> }) {
-      const incoming = req.headers[REQUEST_ID_HEADER];
-      if (typeof incoming === 'string' && incoming.trim()) {
-        return incoming.trim();
-      }
-      return crypto.randomUUID();
     }
   };
 }

--- a/src/util/port-usage.ts
+++ b/src/util/port-usage.ts
@@ -1,0 +1,50 @@
+import { config } from './config.js';
+import { execCmd } from './exec.js';
+
+function parsePortFromLocalAddress(value: string) {
+  const trimmed = value.trim();
+  const match = trimmed.match(/:(\d+)$/);
+  if (!match) return undefined;
+
+  const port = Number(match[1]);
+  if (!Number.isInteger(port) || port <= 0) return undefined;
+  return port;
+}
+
+export function parseListeningTcpPorts(output: string) {
+  const ports = new Set<number>();
+
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    const parts = trimmed.split(/\s+/);
+    const localAddress = parts[3];
+    if (!localAddress) continue;
+
+    const port = parsePortFromLocalAddress(localAddress);
+    if (port) ports.add(port);
+  }
+
+  return ports;
+}
+
+export async function findPortCollisions(ports: number[]) {
+  const result = await execCmd('ss', ['-lntH']);
+  if (result.code !== 0) {
+    throw new Error(`ss_failed:${(result.stderr || result.stdout).trim()}`);
+  }
+
+  const listeningPorts = parseListeningTcpPorts(result.stdout);
+  return ports.filter((port) => listeningPorts.has(port));
+}
+
+export function portsForDesktop(display: number, vncPort: number) {
+  const offset = display - config.displayMin;
+  return [
+    vncPort,
+    config.wsPortMin + offset,
+    config.cdpPortMin + offset,
+    config.aabPortMin + offset
+  ];
+}

--- a/src/util/start-url.ts
+++ b/src/util/start-url.ts
@@ -1,14 +1,21 @@
-function normalizeAllowedDomain(value: string) {
+function normalizeAllowedDomain(value: string): string | undefined {
   const normalized = value.trim().toLowerCase();
   if (!normalized) return undefined;
   return normalized.replace(/^\*\./, '');
 }
 
-export function parseStartUrlDomainAllowlist(raw: string | undefined) {
+export function parseStartUrlDomainAllowlist(
+  raw: string | undefined
+): string[] {
   if (!raw) return [];
 
   return [
-    ...new Set(raw.split(',').map(normalizeAllowedDomain).filter(Boolean))
+    ...new Set(
+      raw
+        .split(',')
+        .map(normalizeAllowedDomain)
+        .filter((domain): domain is string => domain !== undefined)
+    )
   ];
 }
 

--- a/src/util/start-url.ts
+++ b/src/util/start-url.ts
@@ -1,0 +1,29 @@
+function normalizeAllowedDomain(value: string) {
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return undefined;
+  return normalized.replace(/^\*\./, '');
+}
+
+export function parseStartUrlDomainAllowlist(raw: string | undefined) {
+  if (!raw) return [];
+
+  return [
+    ...new Set(raw.split(',').map(normalizeAllowedDomain).filter(Boolean))
+  ];
+}
+
+export function isStartUrlAllowed(startUrl: string, allowedDomains: string[]) {
+  if (allowedDomains.length === 0) return true;
+
+  let hostname: string;
+  try {
+    hostname = new URL(startUrl).hostname.toLowerCase();
+  } catch {
+    return false;
+  }
+
+  return allowedDomains.some(
+    (allowedDomain) =>
+      hostname === allowedDomain || hostname.endsWith(`.${allowedDomain}`)
+  );
+}

--- a/test/integration/server.test.ts
+++ b/test/integration/server.test.ts
@@ -131,6 +131,14 @@ test(
       headers: authHeaders
     });
     assert.equal(withAuth.statusCode, 200);
+
+    const forwardedReqId = await app.inject({
+      method: 'GET',
+      url: '/health',
+      headers: { ...authHeaders, 'x-request-id': 'external-req-123' }
+    });
+    assert.equal(forwardedReqId.statusCode, 200);
+    assert.equal(forwardedReqId.headers['x-request-id'], 'external-req-123');
   }
 );
 

--- a/test/integration/server.test.ts
+++ b/test/integration/server.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+import { PassThrough } from 'node:stream';
 import type { FastifyInstance } from 'fastify';
 
 type ExecCall = { cmd: string; args: string[]; sudo: boolean };
@@ -12,6 +13,7 @@ let calls: ExecCall[] = [];
 let failNginxTest = false;
 let tmpRoot = '';
 let saveFailuresRemaining = 0;
+let loggerOutput = '';
 
 const authHeaders = { authorization: 'Bearer test-token' };
 
@@ -19,11 +21,18 @@ async function importServerWithEnv() {
   tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'aadm-integration-'));
   const stateDir = path.join(tmpRoot, 'state');
   const nginxDir = path.join(tmpRoot, 'nginx');
+  const loggerStream = new PassThrough();
+  loggerOutput = '';
+  loggerStream.setEncoding('utf8');
+  loggerStream.on('data', (chunk) => {
+    loggerOutput += chunk;
+  });
 
   const execMod = await import('../../src/util/exec.ts');
   const configMod = await import('../../src/util/config.ts');
   const netMod = await import('../../src/util/net.ts');
   configMod.config.authToken = 'test-token';
+  configMod.config.ttlSweepIntervalMs = 60_000;
   configMod.config.desktopRouteAuthMode = 'none';
   configMod.config.desktopRouteAuthRequestUrl = 'http://127.0.0.1:3001/verify';
   configMod.config.desktopRouteAuthRequestHeaders = [
@@ -32,6 +41,7 @@ async function importServerWithEnv() {
   ];
   configMod.config.desktopRouteTokenSecret = 'test-secret';
   configMod.config.desktopRouteTokenTtlSeconds = 900;
+  configMod.config.allowedStartUrlDomains = [];
   configMod.config.stateDir = stateDir;
   configMod.config.nginxSnippetDir = nginxDir;
   configMod.config.publicBaseUrl = 'https://host.example.com';
@@ -77,10 +87,10 @@ async function importServerWithEnv() {
   });
 
   const serverMod = await import('../../src/server.ts');
-  app = serverMod.buildApp();
+  app = serverMod.buildApp({ loggerStream });
   await app.ready();
 
-  return { execMod, netMod };
+  return { execMod, netMod, serverMod, configMod };
 }
 
 test.before(async () => {
@@ -141,6 +151,7 @@ test(
     assert.equal(create.statusCode, 200);
     const created = create.json();
     assert.equal(created.id, 'desk-1');
+    assert.ok(create.headers['x-request-id']);
     assert.equal(
       created.novncUrl,
       'https://host.example.com/desktop/1/vnc.html?path=desktop%2F1%2Fwebsockify&resize=remote&autoconnect=1'
@@ -446,5 +457,167 @@ test(
     );
     assert.ok(stopCalls.length >= 1);
     assert.ok(startCalls.length >= 4);
+  }
+);
+
+test(
+  'ttl sweep deletes only desktops whose expiresAt has elapsed',
+  { concurrency: false },
+  async () => {
+    assert.ok(app);
+    const serverMod = await import('../../src/server.ts');
+
+    const before = await app.inject({
+      method: 'GET',
+      url: '/v1/desktops',
+      headers: authHeaders
+    });
+    const beforeIds = before
+      .json()
+      .desktops.map((desktop: { id: string }) => desktop.id);
+
+    const ttlCreate = await app.inject({
+      method: 'POST',
+      url: '/v1/desktops',
+      headers: { ...authHeaders, 'content-type': 'application/json' },
+      payload: { owner: 'codex', label: 'ttl', ttlMinutes: 1 }
+    });
+    assert.equal(ttlCreate.statusCode, 200);
+    const ttlId = ttlCreate.json().id;
+
+    const noTtlCreate = await app.inject({
+      method: 'POST',
+      url: '/v1/desktops',
+      headers: { ...authHeaders, 'content-type': 'application/json' },
+      payload: { owner: 'codex', label: 'no-ttl' }
+    });
+    assert.equal(noTtlCreate.statusCode, 200);
+    const noTtlId = noTtlCreate.json().id;
+
+    const sweep = await serverMod.sweepExpiredDesktops(
+      app,
+      Date.now() + 61_000
+    );
+    assert.deepEqual(sweep.deleted, [ttlId]);
+    assert.deepEqual(sweep.failed, []);
+
+    const after = await app.inject({
+      method: 'GET',
+      url: '/v1/desktops',
+      headers: authHeaders
+    });
+    const afterIds = after
+      .json()
+      .desktops.map((desktop: { id: string }) => desktop.id);
+    assert.deepEqual(
+      afterIds,
+      [...beforeIds, noTtlId],
+      'only ttl-backed desktop should be removed by the sweep'
+    );
+  }
+);
+
+test(
+  'startUrl allowlist rejects unapproved domains',
+  { concurrency: false },
+  async () => {
+    assert.ok(app);
+    const configMod = await import('../../src/util/config.ts');
+    configMod.config.allowedStartUrlDomains = ['github.com'];
+
+    const denied = await app.inject({
+      method: 'POST',
+      url: '/v1/desktops',
+      headers: { ...authHeaders, 'content-type': 'application/json' },
+      payload: {
+        owner: 'codex',
+        label: 'blocked',
+        startUrl: 'https://example.com'
+      }
+    });
+    assert.equal(denied.statusCode, 400);
+    assert.equal(denied.json().error, 'start_url_not_allowed');
+
+    const allowed = await app.inject({
+      method: 'POST',
+      url: '/v1/desktops',
+      headers: { ...authHeaders, 'content-type': 'application/json' },
+      payload: {
+        owner: 'codex',
+        label: 'allowed',
+        startUrl: 'https://gist.github.com/mark'
+      }
+    });
+    assert.equal(allowed.statusCode, 200);
+
+    configMod.config.allowedStartUrlDomains = [];
+  }
+);
+
+test(
+  'create rejects port collisions discovered via ss',
+  { concurrency: false },
+  async () => {
+    assert.ok(app);
+    calls = [];
+    const before = await app.inject({
+      method: 'GET',
+      url: '/v1/desktops',
+      headers: authHeaders
+    });
+    const nextDisplay = before.json().desktops.length + 1;
+    const nextVncPort = 5900 + nextDisplay;
+
+    const execMod = await import('../../src/util/exec.ts');
+    execMod.setExecRunner(async (cmd, args, opts) => {
+      calls.push({ cmd, args, sudo: Boolean(opts?.sudo) });
+
+      if (cmd === 'ss' && args[0] === '-lntH') {
+        return {
+          code: 0,
+          stdout: `LISTEN 0 128 127.0.0.1:${nextVncPort} 0.0.0.0:*\n`,
+          stderr: ''
+        };
+      }
+
+      if (cmd.endsWith('systemctl') && args[0] === 'is-active') {
+        return { code: 0, stdout: 'active\n', stderr: '' };
+      }
+
+      return { code: 0, stdout: '', stderr: '' };
+    });
+
+    const create = await app.inject({
+      method: 'POST',
+      url: '/v1/desktops',
+      headers: { ...authHeaders, 'content-type': 'application/json' },
+      payload: { owner: 'codex', label: 'collision' }
+    });
+    assert.equal(create.statusCode, 409);
+    assert.equal(create.json().error, 'ports_unavailable');
+    assert.deepEqual(create.json().ports, [nextVncPort]);
+  }
+);
+
+test(
+  'request logging redacts token query params and sensitive headers',
+  { concurrency: false },
+  async () => {
+    assert.ok(app);
+
+    const response = await app.inject({
+      method: 'GET',
+      url: '/_aadm/access/desk-1?token=top-secret',
+      headers: { authorization: 'Bearer super-secret' }
+    });
+
+    assert.equal(response.statusCode, 404);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    assert.match(
+      loggerOutput,
+      /"url":"\/_aadm\/access\/desk-1\?token=%5BREDACTED%5D"/
+    );
+    assert.doesNotMatch(loggerOutput, /top-secret/);
+    assert.doesNotMatch(loggerOutput, /super-secret/);
   }
 );

--- a/test/unit/mcp-tools.test.ts
+++ b/test/unit/mcp-tools.test.ts
@@ -43,3 +43,22 @@ test('desktop.get reports manager errors without throwing', async () => {
     data: { ok: false, error: 'not_found' }
   });
 });
+
+test('desktop.get rejects missing ids before calling the manager API', async () => {
+  let called = false;
+
+  const result = await invokeDesktopTool(
+    'desktop.get',
+    {},
+    {
+      fetchImpl: async () => {
+        called = true;
+        return jsonResponse(200, {});
+      }
+    }
+  );
+
+  assert.equal(called, false);
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /invalid_arguments/i);
+});

--- a/test/unit/mcp-tools.test.ts
+++ b/test/unit/mcp-tools.test.ts
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { invokeDesktopTool } from '../../src/mcp/tools.ts';
+
+function jsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' }
+  });
+}
+
+test('desktop.list returns structured MCP content', async () => {
+  const result = await invokeDesktopTool(
+    'desktop.list',
+    {},
+    {
+      fetchImpl: async () => jsonResponse(200, { desktops: [{ id: 'desk-1' }] })
+    }
+  );
+
+  assert.equal(result.isError, undefined);
+  assert.deepEqual(result.structuredContent, {
+    desktops: [{ id: 'desk-1' }]
+  });
+  assert.match(result.content[0].text, /desk-1/);
+});
+
+test('desktop.get reports manager errors without throwing', async () => {
+  const result = await invokeDesktopTool(
+    'desktop.get',
+    { id: 'missing' },
+    {
+      fetchImpl: async () =>
+        jsonResponse(404, { ok: false, error: 'not_found' })
+    }
+  );
+
+  assert.equal(result.isError, true);
+  assert.deepEqual(result.structuredContent, {
+    ok: false,
+    status: 404,
+    data: { ok: false, error: 'not_found' }
+  });
+});

--- a/test/unit/port-usage.test.ts
+++ b/test/unit/port-usage.test.ts
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { parseListeningTcpPorts } from '../../src/util/port-usage.ts';
+
+test('parseListeningTcpPorts extracts IPv4 and IPv6 listener ports', () => {
+  const ports = parseListeningTcpPorts(`
+LISTEN 0 128 127.0.0.1:6081 0.0.0.0:*
+LISTEN 0 128 *:9222 *:*
+LISTEN 0 128 [::]:8765 [::]:*
+`);
+
+  assert.deepEqual(
+    [...ports].sort((a, b) => a - b),
+    [6081, 8765, 9222]
+  );
+});

--- a/test/unit/start-url.test.ts
+++ b/test/unit/start-url.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  isStartUrlAllowed,
+  parseStartUrlDomainAllowlist
+} from '../../src/util/start-url.ts';
+
+test('parseStartUrlDomainAllowlist normalizes and deduplicates domains', () => {
+  assert.deepEqual(
+    parseStartUrlDomainAllowlist('Example.com, *.example.com, github.com'),
+    ['example.com', 'github.com']
+  );
+});
+
+test('isStartUrlAllowed supports exact hosts and subdomains', () => {
+  const allowlist = ['example.com', 'github.com'];
+
+  assert.equal(isStartUrlAllowed('https://example.com', allowlist), true);
+  assert.equal(
+    isStartUrlAllowed('https://www.example.com/path', allowlist),
+    true
+  );
+  assert.equal(isStartUrlAllowed('https://gist.github.com', allowlist), true);
+  assert.equal(isStartUrlAllowed('https://evil-example.com', allowlist), false);
+});


### PR DESCRIPTION
## Summary
- add opt-in TTL sweeping, start URL allowlisting, port collision detection, and request-id log redaction
- add a stdio MCP server wrapper plus shared manager client and docs for Codex/Claude wiring
- update tests, docs, and TODOs to reflect the new hardening surface

## Validation
- npm test
- npm run build
- npm run test:coverage
- npm run prettier